### PR TITLE
Fix for issue-31. Fail to detect volumes with empty attachments

### DIFF
--- a/auto-cleanup/ec2_cleanup.py
+++ b/auto-cleanup/ec2_cleanup.py
@@ -302,7 +302,7 @@ class EC2Cleanup:
                 resource_date = resource.get('CreateTime')
 
                 if resource_id not in self.whitelist.get('ec2', {}).get('volume', []):
-                    if resource.get('Attachments') is None:
+                    if not resource.get('Attachments'):
                         delta = LambdaHelper.get_day_delta(resource_date)
                     
                         if delta.days > ttl_days:


### PR DESCRIPTION
Change condition to properly evaluate empty list.

https://github.com/tianomagdaong/aws-auto-cleanup/blob/hotfix/issue-31/auto-cleanup/ec2_cleanup.py#L305

Also I just want to say thank you, this tool saved me a lot of time.