### PR TITLE
Issue-#37: correcting the reference to LambdaHelper class

### DIFF
--- a/auto_cleanup/lambda_handler.py
+++ b/auto_cleanup/lambda_handler.py
@@ -20,6 +20,7 @@ from . import lambda_cleanup
 from . import redshift_cleanup
 from . import rds_cleanup
 from . import s3_cleanup
+from . import lambda_helper
 
 
 class Cleanup:
@@ -190,7 +191,7 @@ class Cleanup:
                 TableName=os.environ["WHITELISTTABLE"]
             )["Items"]:
                 record_json = dynamodb_json.loads(record, True)
-                parsed_resource_id = lambda_handler.LambdaHelper.parse_resource_id(
+                parsed_resource_id = lambda_helper.LambdaHelper.parse_resource_id(
                     record_json.get("resource_id")
                 )
 


### PR DESCRIPTION
Correcting the reference to LambdaHelper class in lambda_handler.py

## Description
The AutoCleanup lambda wasn't able to read DynamoDB table auto-cleanup-whitelist-${stage}.
The get_whiteList() method of lambda_handler.py used LambdaHelper class which exist in lambda_helper.py , the reference is incorrect.
https://github.com/servian/aws-auto-cleanup/blob/master/auto_cleanup/lambda_handler.py#L193
```
def get_whitelist(self):
                parsed_resource_id = lambda_handler.LambdaHelper.parse_resource_id( .... 
```
```
def get_whitelist(self):
                parsed_resource_id = lambda_helper.LambdaHelper.parse_resource_id( ... 
```
