### PR TITLE
Cleanup tweaks and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added AWS Account ID to the navigation bar and webpage title.
 - Added default sorting (by log name in descending order) within the execution log list table. This ensures the latest execution logs are always first.
+- Added EC2 Image (AMI) cleanup.
 - Added execution log statistics to the execution log popup. Statistics include a breakdown of counts by service, action taken, and region.
 - Added help section to the website introducing new users to Auto Cleanup as well as exposing AWS service settings from the Settings table.
 - Fixed an issue where Auto Cleanup was attempting to delete automated Redshift and RDS snapshots. Only manual snapshots can be deleted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## 1.1.0
 
 - Added default sorting (by Key in descending order) within the execution log list table. This ensures the latest execution logs are always first.
-- Added help section to the website.
+- Added help section to the website introducing new users to Auto Cleanup as well as exposing AWS service settings from the Settings table.
 - Fixed an issue where Auto Cleanup was attempting to delete automated Redshift and RDS snapshots. Only manual snapshots can be deleted.
 - Improved CloudFormation Stacks deletion. Stack Deletions are now be processed in parallel.
-- Improved S3 Bucket deletion by introducing Boto3 `resource` instead of `client`.
+- Improved S3 Bucket deletion by using Boto3 `resource` instead of `client`.
 - Modified AWS Auto Cleanup App memory allocation from 256 MB to 512 MB.
 - Modified AWS Auto Cleanup App timeout from 5 minutes to 15 minutes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0
 
 - Added default sorting (key in descending order) on execution log list table.
+- Added help section to the website.
 - Changed CloudFormation Stacks deletion to be processed in parallel.
 - Fixed issue where automated snapshots (Redshift and RDS) were attempted to be deleted, not just the manual ones.
 - Improved S3 Bucket deletion by introducing Boto3 `resource` instead of `client`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## 1.1.0
 
-- Added default sorting (key in descending order) on execution log list table.
+- Added default sorting (by Key in descending order) within the execution log list table. This ensures the latest execution logs are always first.
 - Added help section to the website.
-- Changed CloudFormation Stacks deletion to be processed in parallel.
-- Fixed issue where automated snapshots (Redshift and RDS) were attempted to be deleted, not just the manual ones.
+- Fixed an issue where Auto Cleanup was attempting to delete automated Redshift and RDS snapshots. Only manual snapshots can be deleted.
+- Improved CloudFormation Stacks deletion. Stack Deletions are now be processed in parallel.
 - Improved S3 Bucket deletion by introducing Boto3 `resource` instead of `client`.
 - Modified AWS Auto Cleanup App memory allocation from 256 MB to 512 MB.
 - Modified AWS Auto Cleanup App timeout from 5 minutes to 15 minutes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.1.0
 
 - Added default sorting (by Key in descending order) within the execution log list table. This ensures the latest execution logs are always first.
-- Added execution log statistics to the execution log popup. Statistic show counts of AWS resources, and actions taken.
+- Added execution log statistics to the execution log popup. Statistics include a breakdown of counts by service, action taken, and region.
 - Added help section to the website introducing new users to Auto Cleanup as well as exposing AWS service settings from the Settings table.
 - Fixed an issue where Auto Cleanup was attempting to delete automated Redshift and RDS snapshots. Only manual snapshots can be deleted.
 - Improved CloudFormation Stacks deletion. Stack Deletions are now be processed in parallel.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## 1.1.0
 
-- Changed CloudFormation Stacks deletion to be done in parallel to save time.
+- Added default sorting (key in descending order) on execution log list table.
+- Changed CloudFormation Stacks deletion to be processed in parallel.
 - Fixed issue where automated snapshots (Redshift and RDS) were attempted to be deleted, not just the manual ones.
 - Improved S3 Bucket deletion by introducing Boto3 `resource` instead of `client`.
+- Modified AWS Auto Cleanup App memory allocation from 256 MB to 512 MB.
+- Modified AWS Auto Cleanup App timeout from 5 minutes to 15 minutes.
 
 ## 1.0.0
 
-- Added serverless API for whitelist, exeuction logs, and settings.
+- Added serverless API for whitelist, execution logs, and settings.
 - Added support for missing regions:
   - af-south-1
   - ap-east-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added help section to the website introducing new users to Auto Cleanup as well as exposing AWS service settings from the Settings table.
 - Fixed an issue where Auto Cleanup was attempting to delete automated Redshift and RDS snapshots. Only manual snapshots can be deleted.
 - Improved CloudFormation Stacks deletion. Stack Deletions are now be processed in parallel.
+- Improved execution logging with finer-grained information.
 - Improved S3 Bucket deletion by using Boto3 `resource` instead of `client`.
 - Modified AWS Auto Cleanup App memory allocation from 256 MB to 512 MB.
 - Modified AWS Auto Cleanup App timeout from 5 minutes to 15 minutes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# AWS Auto Cleanup Changelog
+
+## 1.1.0
+
+- Changed CloudFormation Stacks deletion to be done in parallel to save time.
+- Fixed issue where automated snapshots (Redshift and RDS) were attempted to be deleted, not just the manual ones.
+- Improved S3 Bucket deletion by introducing Boto3 `resource` instead of `client`.
+
+## 1.0.0
+
+- Added serverless API for whitelist, exeuction logs, and settings.
+- Added support for missing regions:
+  - af-south-1
+  - ap-east-1
+  - eu-south-1
+  - me-south-1
+- Added support for new services:
+  - ECS Clusters and Services
+  - Elasticsearch Service Domains
+  - Kinesis Streams
+  - SageMaker Endpoints and Notebook Instances
+- Added web UI for managing your whitelist and viewing execution logs.
+- Replaced GPLv3 with MIT license.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## 1.1.0
 
-- Added default sorting (by Key in descending order) within the execution log list table. This ensures the latest execution logs are always first.
+- Added AWS Account ID to the navigation bar and webpage title.
+- Added default sorting (by log name in descending order) within the execution log list table. This ensures the latest execution logs are always first.
 - Added execution log statistics to the execution log popup. Statistics include a breakdown of counts by service, action taken, and region.
 - Added help section to the website introducing new users to Auto Cleanup as well as exposing AWS service settings from the Settings table.
 - Fixed an issue where Auto Cleanup was attempting to delete automated Redshift and RDS snapshots. Only manual snapshots can be deleted.
-- Improved CloudFormation Stacks deletion. Stack Deletions are now be processed in parallel.
+- Fixed an issue where EC2 Snapshots were incorrectly marked as "in use" and not deleted.
+- Improved CloudFormation Stacks deletion. Stack deletions are now processed in parallel for a given region.
 - Improved execution logging with finer-grained information.
 - Improved S3 Bucket deletion by using Boto3 `resource` instead of `client`.
 - Modified AWS Auto Cleanup App memory allocation from 256 MB to 512 MB.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0
 
 - Added default sorting (by Key in descending order) within the execution log list table. This ensures the latest execution logs are always first.
+- Added execution log statistics to the execution log popup. Statistic show counts of AWS resources, and actions taken.
 - Added help section to the website introducing new users to Auto Cleanup as well as exposing AWS service settings from the Settings table.
 - Fixed an issue where Auto Cleanup was attempting to delete automated Redshift and RDS snapshots. Only manual snapshots can be deleted.
 - Improved CloudFormation Stacks deletion. Stack Deletions are now be processed in parallel.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](./static/banner.png)
 
 <p align="center">
-<a href="https://travis-ci.org/servian/aws-auto-cleanup"><img src="https://travis-ci.org/servian/aws-auto-cleanup.svg?branch=master"></a> <a href="https://www.codacy.com/app/servian/aws-auto-cleanup?utm_source=github.com&utm_medium=referral&utm_content=servian/aws-auto-cleanup&utm_campaign=Badge_Grade"><img src="https://api.codacy.com/project/badge/Grade/4f20fbbb03464b9aa6c558a4415d2288"></a> <a href="https://www.codacy.com/app/servian/aws-auto-cleanup?utm_source=github.com&utm_medium=referral&utm_content=servian/aws-auto-cleanup&utm_campaign=Badge_Coverage"><img src="https://api.codacy.com/project/badge/Coverage/4f20fbbb03464b9aa6c558a4415d2288"></a>
+<a href="https://www.codacy.com/app/servian/aws-auto-cleanup?utm_source=github.com&utm_medium=referral&utm_content=servian/aws-auto-cleanup&utm_campaign=Badge_Grade"><img src="https://api.codacy.com/project/badge/Grade/4f20fbbb03464b9aa6c558a4415d2288"></a>
 </p>
 
 <p align="center">

--- a/api/package.json
+++ b/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-cleanup-api",
   "description": "Auto Cleanup API",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "dependencies": {},
   "devDependencies": {

--- a/app/README.md
+++ b/app/README.md
@@ -113,6 +113,7 @@ The below table indicates AWS resources that are supported by Auto Cleanup along
 | CloudFormation Stacks          | Stack Name             | `cloudformation:stack:stack_name`                    |
 | DynamoDB Tables                | Table Name             | `dynamodb:table:table_name`                          |
 | EC2 Elastic IPs                | Allocation ID          | `ec2:address:allocation_id`                          |
+| EC2 Images                     | Image ID               | `ec2:image:image_id`                                 |
 | EC2 Instances                  | Instance ID            | `ec2:instance:instance_id`                           |
 | EC2 Security Groups            | Group ID               | `ec2:security_group:group_id`                        |
 | EC2 Snapshots                  | Snapshot ID            | `ec2:snapshot:snapshot_id`                           |
@@ -171,6 +172,7 @@ Service-specific settings indicating the supported AWS services, resources, and 
 | CloudFormation        | Stacks                   | True  | 7   |                                                                |
 | DynamoDB              | Tables                   | True  | 7   |                                                                |
 | EC2                   | Addresses                | True  | N/A | Deletes Address if not associated with an EC2 instance.        |
+| EC2                   | Images :new:             | True  | 7   |                                                                |
 | EC2                   | Instances                | True  | 7   |                                                                |
 | EC2                   | Security Groups          | True  | N/A | Deletes Security Group if not associated with an EC2 instance. |
 | EC2                   | Snapshots                | True  | 7   |                                                                |

--- a/app/README.md
+++ b/app/README.md
@@ -68,7 +68,7 @@ The Auto Cleanup App consists of several serverless AWS resource that all work t
 9. Inspect
 
    ```bash
-   serverless logs --function AutoCleanup [--region] [--aws-profile]
+   npm run logs -- [--region] [--aws-profile]
    ```
 
 ## Removal

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-cleanup-app",
   "description": "Auto Cleanup App",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "dependencies": {},
   "devDependencies": {

--- a/app/serverless.yml
+++ b/app/serverless.yml
@@ -24,6 +24,13 @@ provider:
     minimumCompressionSize: 1024
   iamRoleStatements:
     - Effect: Allow
+      Action: "*"
+      Resource: "*"
+      Condition:
+        ForAnyValue:StringEquals:
+          aws:CalledVia:
+            - cloudformation.amazonaws.com
+    - Effect: Allow
       Action:
         - athena:GetQueryExecution
         - athena:GetQueryResults
@@ -34,6 +41,8 @@ provider:
         - cloudformation:DeleteStack
         - cloudformation:DescribeStacks
         - cloudformation:DescribeStackResources
+        - cloudformation:ListStackResources
+        - cloudformation:UpdateTerminationProtection
       Resource: "*"
     - Effect: Allow
       Action:
@@ -169,8 +178,8 @@ functions:
     handler: src/main.lambda_handler
     name: ${self:service}-${self:provider.stage}
     description: Removes unused AWS resources based on time of creation
-    memorySize: 256
-    timeout: 300
+    memorySize: 512
+    timeout: 900
     package:
       include:
         - src/data/**

--- a/app/serverless.yml
+++ b/app/serverless.yml
@@ -146,12 +146,10 @@ provider:
       Resource: "*"
     - Effect: Allow
       Action:
-        - s3:DeleteBucket
-        - s3:DeleteObject
-        - s3:DeleteObjectVersion
+        - s3:Delete*
         - s3:Get*
         - s3:List*
-        - s3:PutObject
+        - s3:Put*
       Resource: "*"
     - Effect: Allow
       Action:

--- a/app/serverless.yml
+++ b/app/serverless.yml
@@ -60,13 +60,13 @@ provider:
         - ec2:DeleteSecurityGroup
         - ec2:DeleteSnapshot
         - ec2:DeleteVolume
+        - ec2:DeregisterImage
         - ec2:DescribeAddresses
         - ec2:DescribeImages
         - ec2:DescribeInstanceAttribute
         - ec2:DescribeInstances
         - ec2:DescribeSecurityGroups
         - ec2:DescribeSnapshots
-        - ec2:DescribeVolumes
         - ec2:DescribeVolumes
         - ec2:ModifyInstanceAttribute
         - ec2:ReleaseAddress

--- a/app/src/cloudformation_cleanup.py
+++ b/app/src/cloudformation_cleanup.py
@@ -33,6 +33,8 @@ class CloudFormationCleanup:
         Deletes CloudFormation Stacks.
         """
 
+        self.logging.debug("Started cleanup of CloudFormation Stacks.")
+
         clean = (
             self.settings.get("services", {})
             .get("cloudformation", {})
@@ -70,6 +72,8 @@ class CloudFormationCleanup:
             # make sure that all threads have finished
             for thread in threads:
                 thread.join()
+
+            self.logging.debug("Finished cleanup of CloudFormation Stacks.")
         else:
             self.logging.info("Skipping cleanup of CloudFormation Stacks.")
             return True

--- a/app/src/cloudformation_cleanup.py
+++ b/app/src/cloudformation_cleanup.py
@@ -149,12 +149,12 @@ class CloudFormationCleanup:
                                 WaiterConfig={"Delay": 5, "MaxAttempts": 6},
                             )
                         except:
-                            self.logging.error(
+                            self.logging.warn(
                                 f"Did not delete CloudFormation Stack '{resource_id}' within 30 seconds. "
                                 "Stopped waiting, check progress manually."
                             )
                             self.logging.warn(sys.exc_info()[1])
-                            self.log_execution(resource_id, "warn")
+                            self.log_execution(resource_id, "delete - timeout")
                             return False
                     except:
                         self.logging.error(

--- a/app/src/cloudformation_cleanup.py
+++ b/app/src/cloudformation_cleanup.py
@@ -1,5 +1,6 @@
 import sys
 import datetime
+import threading
 
 import boto3
 
@@ -53,90 +54,175 @@ class CloudFormationCleanup:
                 .get("ttl", 7)
             )
 
+            # threads list
+            threads = []
+
             for resource in resources:
-                resource_id = resource.get("StackName")
-                resource_date = (
-                    resource.get("LastUpdatedTime")
-                    if resource.get("LastUpdatedTime") is not None
-                    else resource.get("CreationTime")
+                thread = threading.Thread(
+                    target=self.delete_stack, args=(resource, ttl_days)
                 )
-                resource_action = "skip"
+                threads.append(thread)
 
-                if resource_id not in self.whitelist.get("cloudformation", {}).get(
-                    "stack", []
-                ):
-                    delta = Helper.get_day_delta(resource_date)
-                    if delta.days > ttl_days:
-                        if not self.settings.get("general", {}).get("dry_run", True):
-                            try:
-                                self.client_cloudformation.delete_stack(
-                                    StackName=resource_id
-                                )
-                            except:
-                                self.logging.error(
-                                    f"Could not delete CloudFormation Stack '{resource_id}'."
-                                )
-                                self.logging.error(sys.exc_info()[1])
-                                resource_action = "error"
-                                continue
+            # start all threads
+            for thread in threads:
+                thread.start()
 
-                        self.logging.info(
-                            f"CloudFormation Stack '{resource_id}' was last modified {delta.days} days ago "
-                            "and has been deleted."
-                        )
-                        resource_action = "delete"
-                    else:
-                        self.logging.debug(
-                            f"CloudFormation Stack '{resource_id}' was last modified {delta.days} days ago "
-                            "(less than TTL setting) and has not been deleted."
-                        )
-                        resource_action = "skip - TTL"
-                else:
-                    self.logging.debug(
-                        f"CloudFormation Stack '{resource_id}' has been whitelisted and has not "
-                        "been deleted."
-                    )
-                    resource_action = "skip - whitelist"
-
-                self.execution_log.get("AWS").setdefault(self.region, {}).setdefault(
-                    "CloudFormation", {}
-                ).setdefault("Stack", []).append(
-                    {
-                        "id": resource_id,
-                        "action": resource_action,
-                        "timestamp": datetime.datetime.now().strftime(
-                            "%Y-%m-%d %H:%M:%S"
-                        ),
-                    }
-                )
-
-                # For CloudFormation Stacks that are not deleted, add all physical
-                # resources into the Whitelist dictionary to prevent the need to whitelist
-                # each and every resource
-                if resource_action != "delete":
-                    try:
-                        resource_details = (
-                            self.client_cloudformation.describe_stack_resources(
-                                StackName=resource_id
-                            ).get("StackResources")
-                        )
-                    except:
-                        self.logging.error("Could not Describe Stack Resources.")
-                        self.logging.error(sys.exc_info()[1])
-                        return False
-
-                    for _ in resource_details:
-                        resource_child_id = _.get("PhysicalResourceId")
-                        platform, service, resource = _.get("ResourceType").split("::")
-
-                        self.whitelist.setdefault(service.lower(), {}).setdefault(
-                            resource.lower(), set()
-                        ).add(resource_child_id)
-
-                        self.logging.debug(
-                            f"{service} {resource} '{resource_child_id}' has been added to the whitelist."
-                        )
-            return True
+            # make sure that all threads have finished
+            for thread in threads:
+                thread.join()
         else:
             self.logging.info("Skipping cleanup of CloudFormation Stacks.")
             return True
+
+    def delete_stack(self, resource, ttl_days):
+        resource_id = resource.get("StackName")
+        resource_date = (
+            resource.get("LastUpdatedTime")
+            if resource.get("LastUpdatedTime") is not None
+            else resource.get("CreationTime")
+        )
+        resource_status = resource.get("StackStatus")
+        resource_protection = True  # resource.get("EnableTerminationProtection")
+        resource_action = "skip"
+
+        if resource_id not in self.whitelist.get("cloudformation", {}).get("stack", []):
+            delta = Helper.get_day_delta(resource_date)
+            if delta.days > ttl_days:
+                if not self.settings.get("general", {}).get("dry_run", True):
+                    # form a list of resources that cannot be delete
+                    retain_resources = []
+                    if resource_status in ("DELETE_FAILED"):
+                        try:
+                            stack_resources = (
+                                self.client_cloudformation.list_stack_resources(
+                                    StackName=resource_id
+                                )
+                            ).get("StackResourceSummaries")
+                        except:
+                            self.logging.error(
+                                f"Could not retrieve a list of Stack Resources for CloudFormation Stack '{resource_id}'."
+                            )
+                            self.logging.error(sys.exc_info()[1])
+                            self.log_execution(resource_id, "error")
+                            return False
+
+                        for stack_resource in stack_resources:
+                            if stack_resource.get("ResourceStatus") in (
+                                "DELETE_FAILED"
+                            ) and stack_resource.get("ResourceType") in (
+                                "AWS::S3::Bucket"
+                            ):
+                                retain_resources.append(
+                                    stack_resource.get("LogicalResourceId")
+                                )
+
+                    # remove termination protection
+                    if resource_protection:
+                        try:
+                            self.client_cloudformation.update_termination_protection(
+                                EnableTerminationProtection=False,
+                                StackName=resource_id,
+                            )
+                            self.logging.info(
+                                f"Termination Protection for CloudFormation Stack '{resource_id}' disabled."
+                            )
+                        except:
+                            self.logging.error(
+                                f"Could not disable Termination Protection for CloudFormation Stack '{resource_id}'."
+                            )
+                            self.logging.error(sys.exc_info()[1])
+                            self.log_execution(resource_id, "error")
+                            return False
+
+                    try:
+                        self.client_cloudformation.delete_stack(
+                            StackName=resource_id,
+                            RetainResources=retain_resources,
+                        )
+
+                        waiter = self.client_cloudformation.get_waiter(
+                            "stack_delete_complete"
+                        )
+                        try:
+                            waiter.wait(
+                                StackName=resource_id,
+                                WaiterConfig={"Delay": 5, "MaxAttempts": 6},
+                            )
+                        except:
+                            self.logging.error(
+                                f"Did not delete CloudFormation Stack '{resource_id}' within 30 seconds. "
+                                "Stopped waiting, check progress manually."
+                            )
+                            self.logging.warn(sys.exc_info()[1])
+                            self.log_execution(resource_id, "warn")
+                            return False
+                    except:
+                        self.logging.error(
+                            f"Could not delete CloudFormation Stack '{resource_id}'. "
+                            "Manual deletion by an administrator might be necessary."
+                        )
+                        self.logging.error(sys.exc_info()[1])
+                        self.log_execution(resource_id, "error")
+                        return False
+
+                self.logging.info(
+                    f"CloudFormation Stack '{resource_id}' was last modified {delta.days} days ago "
+                    "and has been deleted."
+                )
+                resource_action = "delete"
+            else:
+                self.logging.debug(
+                    f"CloudFormation Stack '{resource_id}' was last modified {delta.days} days ago "
+                    "(less than TTL setting) and has not been deleted."
+                )
+                resource_action = "skip - TTL"
+        else:
+            self.logging.debug(
+                f"CloudFormation Stack '{resource_id}' has been whitelisted and has not "
+                "been deleted."
+            )
+            resource_action = "skip - whitelist"
+
+        self.log_execution(resource_id, resource_action)
+
+        # For CloudFormation Stacks that are not deleted, add all physical
+        # resources into the Whitelist dictionary to prevent the need to whitelist
+        # each and every resource
+        if resource_action != "delete":
+            try:
+                resource_details = self.client_cloudformation.describe_stack_resources(
+                    StackName=resource_id
+                ).get("StackResources")
+            except:
+                self.logging.error("Could not Describe Stack Resources.")
+                self.logging.error(sys.exc_info()[1])
+                return False
+
+            for _ in resource_details:
+                resource_child_id = _.get("PhysicalResourceId")
+                platform, service, resource = _.get("ResourceType").split("::")
+
+                self.whitelist.setdefault(service.lower(), {}).setdefault(
+                    resource.lower(), set()
+                ).add(resource_child_id)
+
+                self.logging.debug(
+                    f"{service} {resource} '{resource_child_id}' has been added to the whitelist."
+                )
+
+        return True
+
+    def log_execution(self, resource_id, resource_action):
+        """
+        Record action taken to the execution log
+        """
+
+        self.execution_log.get("AWS").setdefault(self.region, {}).setdefault(
+            "CloudFormation", {}
+        ).setdefault("Stack", []).append(
+            {
+                "id": resource_id,
+                "action": resource_action,
+                "timestamp": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            }
+        )

--- a/app/src/data/auto-cleanup-settings.json
+++ b/app/src/data/auto-cleanup-settings.json
@@ -4,7 +4,7 @@
       "S": "version"
     },
     "value": {
-      "N": "2"
+      "N": "3"
     }
   },
   {
@@ -68,6 +68,19 @@
                 },
                 "id": {
                   "S": "allocation_id"
+                }
+              }
+            },
+            "image": {
+              "M": {
+                "clean": {
+                  "BOOL": true
+                },
+                "id": {
+                  "S": "image_id"
+                },
+                "ttl": {
+                  "N": "7"
                 }
               }
             },

--- a/app/src/dynamodb_cleanup.py
+++ b/app/src/dynamodb_cleanup.py
@@ -52,11 +52,19 @@ class DynamoDBCleanup:
             )
 
             for resource in resources:
-                resource_date = (
-                    self.client_dynamodb.describe_table(TableName=resource)
-                    .get("Table")
-                    .get("CreationDateTime")
-                )
+                try:
+                    resource_details = self.client_dynamodb.describe_table(
+                        TableName=resource
+                    ).get("Table")
+                except:
+                    self.logging.error(
+                        f"Could not get DynamoDB Table's '{resource}' details."
+                    )
+                    self.logging.error(sys.exc_info()[1])
+                    resource_action = "error"
+                    continue
+
+                resource_date = resource_details.get("CreationDateTime")
                 resource_action = "skip"
 
                 if resource not in self.whitelist.get("dynamodb", {}).get("table", []):

--- a/app/src/dynamodb_cleanup.py
+++ b/app/src/dynamodb_cleanup.py
@@ -30,6 +30,8 @@ class DynamoDBCleanup:
         Deletes DynamoDB Tables.
         """
 
+        self.logging.debug("Started cleanup of DynamoDB Tables.")
+
         clean = (
             self.settings.get("services", {})
             .get("dynamodb", {})
@@ -110,6 +112,8 @@ class DynamoDBCleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of DynamoDB Tables.")
             return True
         else:
             self.logging.info("Skipping cleanup of DynamoDB Tables.")

--- a/app/src/ec2_cleanup.py
+++ b/app/src/ec2_cleanup.py
@@ -91,11 +91,11 @@ class EC2Cleanup:
                         )
                         resource_action = "delete"
                     else:
-                        self.logging.debug(
+                        self.logging.warn(
                             f"EC2 Address '{resource_id}' is associated with an EC2 instance and has not "
                             "been deleted."
                         )
-                        resource_action = "skip"
+                        resource_action = "skip - in use"
                 else:
                     self.logging.debug(
                         f"EC2 Address '{resource_id}' has been whitelisted and has not "
@@ -390,6 +390,7 @@ class EC2Cleanup:
                     except:
                         self.logging.error(f"Could not retrieve EC2 AMIs.")
                         self.logging.error(sys.exc_info()[1])
+                        resource_action = "error"
                         continue
 
                     for image in images:
@@ -439,15 +440,16 @@ class EC2Cleanup:
                             )
                             resource_action = "skip - TTL"
                     else:
-                        self.logging.debug(
+                        self.logging.warn(
                             f"EC2 Snapshot '{resource_id}' is currently used by an AMI "
                             "and cannot been deleted without deleting the AMI first."
                         )
-                        resource_action = "skip"
+                        resource_action = "skip - in use"
                 else:
                     self.logging.debug(
                         f"EC2 Snapshot '{resource_id}' has been whitelisted and has not been deleted."
                     )
+                    resource_action = "skip - whitelist"
 
                 self.execution_log.get("AWS").setdefault(self.region, {}).setdefault(
                     "EC2", {}
@@ -526,10 +528,11 @@ class EC2Cleanup:
                             )
                             resource_action = "skip - TTL"
                     else:
-                        self.logging.debug(
+                        self.logging.warn(
                             f"EC2 Volume '{resource_id}' is attached to an EC2 instance "
                             "and has not been deleted."
                         )
+                        resource_action = "skip - in use"
                 else:
                     self.logging.debug(
                         f"EC2 Volume '{resource_id}' has been whitelisted and has not been deleted."

--- a/app/src/ec2_cleanup.py
+++ b/app/src/ec2_cleanup.py
@@ -465,7 +465,9 @@ class EC2Cleanup:
         if clean:
             try:
                 resources = self.client_ec2.describe_snapshots(
-                    OwnerIds=[self.account_number]
+                    OwnerIds=[
+                        "self",
+                    ]
                 ).get("Snapshots")
             except:
                 self.logging.error("Could not list all EC2 Snapshots.")
@@ -507,14 +509,7 @@ class EC2Cleanup:
                                     block_device_mapping.get("Ebs").get("SnapshotId")
                                 )
 
-                    # cannot retrieve all image to snapshot mappings for whatever reason
-                    # to work around this, looking at the Description field of the Snapshot
-                    # tells us if the Snapshot was made for an Image hence prevention its deletion
-                    # without first deleting the Image
-                    if (
-                        resource_id not in snapshots_in_use
-                        and "for ami-" not in resource.get("Description")
-                    ):
+                    if resource_id not in snapshots_in_use:
                         delta = Helper.get_day_delta(resource_date)
 
                         if delta.days > ttl_days:

--- a/app/src/ec2_cleanup.py
+++ b/app/src/ec2_cleanup.py
@@ -42,6 +42,7 @@ class EC2Cleanup:
 
     def run(self):
         self.addresses()
+        self.images()
         self.instances()
         self.security_groups()
         self.snapshots()
@@ -51,6 +52,8 @@ class EC2Cleanup:
         """
         Deletes Addresses not allocated to an EC2 Instance.
         """
+
+        self.logging.debug("Started cleanup of EC2 Addresses.")
 
         clean = (
             self.settings.get("services", {})
@@ -114,9 +117,99 @@ class EC2Cleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of EC2 Addresses.")
             return True
         else:
             self.logging.info("Skipping cleanup of EC2 Addresses.")
+            return True
+
+    def images(self):
+        """
+        Deletes Images not allocated to an EC2 Instance.
+        """
+
+        self.logging.debug("Started cleanup of EC2 Images.")
+
+        clean = (
+            self.settings.get("services", {})
+            .get("ec2", {})
+            .get("image", {})
+            .get("clean", False)
+        )
+        if clean:
+            try:
+                resources = self.client_ec2.describe_images(
+                    Owners=[
+                        "self",
+                    ]
+                ).get("Images")
+            except:
+                self.logging.error("Could not list all EC2 Images.")
+                self.logging.error(sys.exc_info()[1])
+                return False
+
+            ttl_days = (
+                self.settings.get("services", {})
+                .get("ec2", {})
+                .get("image", {})
+                .get("ttl", 7)
+            )
+
+            for resource in resources:
+                resource_id = resource.get("ImageId")
+                resource_date = resource.get("CreationDate")
+                resource_action = "skip"
+
+                if resource_id not in self.whitelist.get("ec2", {}).get("image", []):
+                    delta = Helper.get_day_delta(resource_date)
+
+                    if delta.days > ttl_days:
+                        if not self.settings.get("general", {}).get("dry_run", True):
+                            try:
+                                self.client_ec2.deregister_image(ImageId=resource_id)
+                            except:
+                                self.logging.error(
+                                    f"Could not deregister EC2 Image '{resource_id}'."
+                                )
+                                self.logging.error(sys.exc_info()[1])
+                                resource_action = "error"
+                                continue
+
+                        self.logging.info(
+                            f"EC2 Image '{resource_id}' was last modified {delta.days} days ago "
+                            "and has been deregistered."
+                        )
+                        resource_action = "delete"
+                    else:
+                        self.logging.debug(
+                            f"EC2 Image '{resource_id}' was last modified {delta.days} days ago "
+                            "(less than TTL setting) and has not been deregistered."
+                        )
+                        resource_action = "skip - TTL"
+                else:
+                    self.logging.debug(
+                        f"EC2 Image '{resource_id}' has been whitelisted and has not "
+                        "been deregistered."
+                    )
+                    resource_action = "skip - whitelist"
+
+                self.execution_log.get("AWS").setdefault(self.region, {}).setdefault(
+                    "EC2", {}
+                ).setdefault("Image", []).append(
+                    {
+                        "id": resource_id,
+                        "action": resource_action,
+                        "timestamp": datetime.datetime.now().strftime(
+                            "%Y-%m-%d %H:%M:%S"
+                        ),
+                    }
+                )
+
+            self.logging.debug("Finished cleanup of EC2 Images.")
+            return True
+        else:
+            self.logging.info("Skipping cleanup of EC2 Images.")
             return True
 
     def instances(self):
@@ -125,6 +218,8 @@ class EC2Cleanup:
         If Instance has termination protection enabled, the protection will
         be first disabled and then the Instance will be terminated.
         """
+
+        self.logging.debug("Started cleanup of EC2 Instances.")
 
         clean = (
             self.settings.get("services", {})
@@ -261,6 +356,8 @@ class EC2Cleanup:
                             ),
                         }
                     )
+
+            self.logging.debug("Finished cleanup of EC2 Instances.")
             return True
         else:
             self.logging.info("Skipping cleanup of EC2 Instances.")
@@ -270,6 +367,8 @@ class EC2Cleanup:
         """
         Deletes Security Groups not attached to an EC2 Instance.
         """
+
+        self.logging.debug("Started cleanup of EC2 Security Groups.")
 
         clean = (
             self.settings.get("services", {})
@@ -343,6 +442,8 @@ class EC2Cleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of EC2 Security Groups.")
             return True
         else:
             self.logging.info("Skipping cleanup of EC2 Security Groups.")
@@ -352,6 +453,8 @@ class EC2Cleanup:
         """
         Deletes Snapshots not attached to EBS volumes.
         """
+
+        self.logging.debug("Started cleanup of EC2 Snapshots.")
 
         clean = (
             self.settings.get("services", {})
@@ -385,10 +488,12 @@ class EC2Cleanup:
                     snapshots_in_use = []
                     try:
                         images = self.client_ec2.describe_images(
-                            ExecutableUsers=[self.account_number]
+                            Owners=[
+                                "self",
+                            ]
                         ).get("Images")
                     except:
-                        self.logging.error(f"Could not retrieve EC2 AMIs.")
+                        self.logging.error(f"Could not retrieve EC2 Images.")
                         self.logging.error(sys.exc_info()[1])
                         resource_action = "error"
                         continue
@@ -404,8 +509,8 @@ class EC2Cleanup:
 
                     # cannot retrieve all image to snapshot mappings for whatever reason
                     # to work around this, looking at the Description field of the Snapshot
-                    # tells us if the Snapshot was made for an AMI hence prevention its deletion
-                    # without first deleting the AMI
+                    # tells us if the Snapshot was made for an Image hence prevention its deletion
+                    # without first deleting the Image
                     if (
                         resource_id not in snapshots_in_use
                         and "for ami-" not in resource.get("Description")
@@ -441,8 +546,8 @@ class EC2Cleanup:
                             resource_action = "skip - TTL"
                     else:
                         self.logging.warn(
-                            f"EC2 Snapshot '{resource_id}' is currently used by an AMI "
-                            "and cannot been deleted without deleting the AMI first."
+                            f"EC2 Snapshot '{resource_id}' is currently used by an Image "
+                            "and cannot been deleted without deleting the Image first."
                         )
                         resource_action = "skip - in use"
                 else:
@@ -462,6 +567,8 @@ class EC2Cleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of EC2 Snapshots.")
             return True
         else:
             self.logging.info("Skipping cleanup of EC2 Snapshots.")
@@ -471,6 +578,8 @@ class EC2Cleanup:
         """
         Deletes Volumes not attached to an EC2 Instance.
         """
+
+        self.logging.debug("Started cleanup of EC2 Volumes.")
 
         clean = (
             self.settings.get("services", {})
@@ -550,6 +659,8 @@ class EC2Cleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Started cleanup of EC2 Volumes.")
             return True
         else:
             self.logging.info("Skipping cleanup of EC2 Volumes.")

--- a/app/src/ec2_cleanup.py
+++ b/app/src/ec2_cleanup.py
@@ -256,9 +256,9 @@ class EC2Cleanup:
                         {
                             "id": resource_id,
                             "action": resource_action,
-                            "timestamp": datetime.datetime.now()
-                            .astimezone()
-                            .isoformat(),
+                            "timestamp": datetime.datetime.now().strftime(
+                                "%Y-%m-%d %H:%M:%S"
+                            ),
                         }
                     )
             return True

--- a/app/src/ecs_cleanup.py
+++ b/app/src/ecs_cleanup.py
@@ -71,22 +71,22 @@ class ECSCleanup:
                 if resource_id not in self.whitelist.get("ecs", {}).get("cluster", []):
                     if not self.settings.get("general", {}).get("dry_run", True):
                         if resource_status not in ("ACTIVE", "FAILED"):
-                            self.logging.error(
+                            self.logging.warn(
                                 f"ECS Cluster '{resource_id}' in state '{resource_status}' cannot be deleted."
                             )
-                            resource_action = "error"
+                            resource_action = "skip - in use"
                             continue
                         elif resource_active_service_count > 0:
-                            self.logging.error(
+                            self.logging.warn(
                                 f"ECS Cluster '{resource_id}' has {resource_active_service_count} active services running and cannot be deleted."
                             )
-                            resource_action = "error"
+                            resource_action = "skip - in use"
                             continue
                         elif resource_running_task_count > 0:
-                            self.logging.error(
+                            self.logging.warn(
                                 f"ECS Cluster '{resource_id}' has {resource_running_task_count} running tasks and cannot be deleted."
                             )
-                            resource_action = "error"
+                            resource_action = "skip - in use"
                             continue
                         else:
                             try:
@@ -101,10 +101,8 @@ class ECSCleanup:
                                 resource_action = "error"
                                 continue
 
-                            self.logging.info(
-                                f"ECS Cluster '{resource_id}' has been deleted."
-                            )
-                            resource_action = "delete"
+                    self.logging.info(f"ECS Cluster '{resource_id}' has been deleted.")
+                    resource_action = "delete"
                 else:
                     self.logging.debug(
                         f"ECS Cluster '{resource_id}' has been whitelisted and has not been deleted."
@@ -209,10 +207,11 @@ class ECSCleanup:
                                         resource_action = "error"
                                         continue
                                 else:
-                                    self.logging.error(
+                                    self.logging.warn(
                                         f"ECS Service '{resource_id}' in state '{resource_status}' cannot be deleted."
                                     )
-                                    resource_action = "error"
+                                    resource_action = "skip - in use"
+                                    continue
 
                             self.logging.info(
                                 f"ECS Service '{resource_id}' was created {delta.days} days ago "

--- a/app/src/ecs_cleanup.py
+++ b/app/src/ecs_cleanup.py
@@ -57,6 +57,7 @@ class ECSCleanup:
                         f"Could not get ECS Cluster's '{resource}' details."
                     )
                     self.logging.error(sys.exc_info()[1])
+                    resource_action = "error"
                     return False
 
                 resource_id = resource_details.get("clusterName")

--- a/app/src/ecs_cleanup.py
+++ b/app/src/ecs_cleanup.py
@@ -31,6 +31,8 @@ class ECSCleanup:
         Deletes ECS Clusters.
         """
 
+        self.logging.debug("Started cleanup of ECS Clusters.")
+
         clean = (
             self.settings.get("services", {})
             .get("ecs", {})
@@ -120,6 +122,8 @@ class ECSCleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of ECS Clusters.")
             return True
         else:
             self.logging.info("Skipping cleanup of ECS Clusters.")
@@ -129,6 +133,8 @@ class ECSCleanup:
         """
         Deletes ECS Services.
         """
+
+        self.logging.debug("Started cleanup of ECS Services.")
 
         clean = (
             self.settings.get("services", {})
@@ -241,7 +247,9 @@ class ECSCleanup:
                             ),
                         }
                     )
-                return True
+
+            self.logging.debug("Finished cleanup of ECS Services.")
+            return True
         else:
             self.logging.info("Skipping cleanup of ECS Services.")
             return True

--- a/app/src/ecs_cleanup.py
+++ b/app/src/ecs_cleanup.py
@@ -111,8 +111,8 @@ class ECSCleanup:
                     resource_action = "skip - whitelist"
 
                 self.execution_log.get("AWS").setdefault(self.region, {}).setdefault(
-                    "ecs", {}
-                ).setdefault("cluster", []).append(
+                    "ECS", {}
+                ).setdefault("Cluster", []).append(
                     {
                         "id": resource_id,
                         "action": resource_action,
@@ -232,7 +232,7 @@ class ECSCleanup:
 
                     self.execution_log.get("AWS").setdefault(
                         self.region, {}
-                    ).setdefault("ecs", {}).setdefault("service", []).append(
+                    ).setdefault("ECS", {}).setdefault("Service", []).append(
                         {
                             "id": resource_id,
                             "action": resource_action,

--- a/app/src/elasticbeanstalk_cleanup.py
+++ b/app/src/elasticbeanstalk_cleanup.py
@@ -32,6 +32,8 @@ class ElasticBeanstalkCleanup:
         Deletes Elastic Beanstalk Applications.
         """
 
+        self.logging.debug("Started cleanup of Elastic Beanstalk Applications.")
+
         clean = (
             self.settings.get("services", {})
             .get("elasticbeanstalk", {})
@@ -108,6 +110,8 @@ class ElasticBeanstalkCleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of Elastic Beanstalk Applications.")
             return True
         else:
             self.logging.info("Skipping cleanup of Elastic Beanstalk Applications.")

--- a/app/src/elasticsearch_cleanup.py
+++ b/app/src/elasticsearch_cleanup.py
@@ -97,11 +97,11 @@ class ElasticsearchServiceCleanup:
                                 resource_action = "error"
                                 continue
 
-                            self.logging.info(
-                                f"Elasticsearch Service Domain '{resource_id}' was last modified {delta.days} days ago "
-                                "and has been deleted."
-                            )
-                            resource_action = "delete"
+                        self.logging.info(
+                            f"Elasticsearch Service Domain '{resource_id}' was last modified {delta.days} days ago "
+                            "and has been deleted."
+                        )
+                        resource_action = "delete"
                     else:
                         self.logging.debug(
                             f"Elasticsearch Service Domain '{resource_id}' was created {delta.days} days ago "

--- a/app/src/elasticsearch_cleanup.py
+++ b/app/src/elasticsearch_cleanup.py
@@ -68,6 +68,7 @@ class ElasticsearchServiceCleanup:
                         f"Could not get Elasticsearch Service Domain '{resource_id}' details."
                     )
                     self.logging.error(sys.exc_info()[1])
+                    resource_action = "error"
                     return False
 
                 resource_date = (

--- a/app/src/elasticsearch_cleanup.py
+++ b/app/src/elasticsearch_cleanup.py
@@ -114,8 +114,8 @@ class ElasticsearchServiceCleanup:
                     resource_action = "skip - whitelist"
 
                 self.execution_log.get("AWS").setdefault(self.region, {}).setdefault(
-                    "elasticsearch", {}
-                ).setdefault("domain", []).append(
+                    "Elasticsearch Service", {}
+                ).setdefault("Domain", []).append(
                     {
                         "id": resource_id,
                         "action": resource_action,

--- a/app/src/elasticsearch_cleanup.py
+++ b/app/src/elasticsearch_cleanup.py
@@ -30,6 +30,8 @@ class ElasticsearchServiceCleanup:
         Deletes Elasticsearch Service Domains.
         """
 
+        self.logging.debug("Started cleanup of Elasticsearch Service Domains.")
+
         clean = (
             self.settings.get("services", {})
             .get("elasticsearch", {})
@@ -125,6 +127,8 @@ class ElasticsearchServiceCleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of Elasticsearch Service Domains.")
             return True
         else:
             self.logging.info("Skipping cleanup of Elasticsearch Service Domains.")

--- a/app/src/emr_cleanup.py
+++ b/app/src/emr_cleanup.py
@@ -30,6 +30,8 @@ class EMRCleanup:
         Deletes EMR Clusters.
         """
 
+        self.logging.debug("Started cleanup of EMR Clusters.")
+
         clean = (
             self.settings.get("services", {})
             .get("emr", {})
@@ -112,6 +114,8 @@ class EMRCleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of EMR Clusters.")
             return True
         else:
             self.logging.info("Skipping cleanup of EMR Clusters.")

--- a/app/src/emr_cleanup.py
+++ b/app/src/emr_cleanup.py
@@ -85,10 +85,10 @@ class EMRCleanup:
                             )
                             resource_action = "delete"
                         else:
-                            self.logging.error(
+                            self.logging.warn(
                                 f"EMR Cluster '{resource_id}' in state '{resource_status}' cannot be deleted."
                             )
-                            resource_action = "error"
+                            resource_action = "skip - in use"
                     else:
                         self.logging.debug(
                             f"EMR Cluster '{resource_id}' was created {delta.days} days ago "

--- a/app/src/glue_cleanup.py
+++ b/app/src/glue_cleanup.py
@@ -30,6 +30,8 @@ class GlueCleanup:
         Deletes Glue Dev Endpoints.
         """
 
+        self.logging.debug("Started cleanup of Glue Dev Endpoints.")
+
         clean = (
             self.settings.get("services", {})
             .get("glue", {})
@@ -103,6 +105,8 @@ class GlueCleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of Glue Dev Endpoints.")
             return True
         else:
             self.logging.info("Skipping cleanup of Glue Dev Endpoints.")

--- a/app/src/iam_cleanup.py
+++ b/app/src/iam_cleanup.py
@@ -31,6 +31,8 @@ class IAMCleanup:
         Deletes IAM Roles.
         """
 
+        self.logging.debug("Started cleanup of IAM Roles.")
+
         clean = (
             self.settings.get("services", {})
             .get("iam", {})
@@ -312,6 +314,8 @@ class IAMCleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of IAM Roles.")
             return True
         else:
             self.logging.info("Skipping cleanup of IAM Roles.")

--- a/app/src/kinesis_cleanup.py
+++ b/app/src/kinesis_cleanup.py
@@ -91,10 +91,11 @@ class KinesisCleanup:
                                     resource_action = "error"
                                     continue
                             else:
-                                self.logging.error(
+                                self.logging.warn(
                                     f"Kinesis Stream '{resource_id}' in state '{resource_status}' cannot be deleted."
                                 )
-                                resource_action = "error"
+                                resource_action = "skip - in use"
+                                continue
 
                         self.logging.info(
                             f"Kinesis Stream '{resource_id}' was created {delta.days} days ago "

--- a/app/src/kinesis_cleanup.py
+++ b/app/src/kinesis_cleanup.py
@@ -113,8 +113,8 @@ class KinesisCleanup:
                     resource_action = "skip - whitelist"
 
                 self.execution_log.get("AWS").setdefault(self.region, {}).setdefault(
-                    "kinesis", {}
-                ).setdefault("stream", []).append(
+                    "Kinesis", {}
+                ).setdefault("Stream", []).append(
                     {
                         "id": resource_id,
                         "action": resource_action,

--- a/app/src/kinesis_cleanup.py
+++ b/app/src/kinesis_cleanup.py
@@ -63,6 +63,7 @@ class KinesisCleanup:
                         f"Could not get Kinesis Stream's '{resource_id}' details."
                     )
                     self.logging.error(sys.exc_info()[1])
+                    resource_action = "error"
                     return False
 
                 resource_status = resource_details.get("StreamStatus")

--- a/app/src/kinesis_cleanup.py
+++ b/app/src/kinesis_cleanup.py
@@ -30,6 +30,8 @@ class KinesisCleanup:
         Deletes Kinesis Streams.
         """
 
+        self.logging.debug("Started cleanup of Kinesis Streams.")
+
         clean = (
             self.settings.get("services", {})
             .get("kinesis", {})
@@ -125,6 +127,8 @@ class KinesisCleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of Kinesis Streams.")
             return True
         else:
             self.logging.info("Skipping cleanup of Kinesis Streams.")

--- a/app/src/lambda_cleanup.py
+++ b/app/src/lambda_cleanup.py
@@ -31,6 +31,8 @@ class LambdaCleanup:
         Deletes Lambda Functions.
         """
 
+        self.logging.debug("Started cleanup of Lambda Functions.")
+
         clean = (
             self.settings.get("services", {})
             .get("lambda", {})
@@ -104,6 +106,8 @@ class LambdaCleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of Lambda Functions.")
             return True
         else:
             self.logging.info("Skipping cleanup of Lambda Functions.")

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -47,7 +47,7 @@ class Cleanup:
         else:
             self.logging.info(f"Auto Cleanup started in DESTROY mode.")
 
-        for region in self.settings.get("regions"):
+        for region in sorted(self.settings.get("regions")):
             if self.settings.get("regions").get(region).get("clean"):
                 self.logging.info(f"Switching to '{region}' region.")
 

--- a/app/src/rds_cleanup.py
+++ b/app/src/rds_cleanup.py
@@ -144,7 +144,9 @@ class RDSCleanup:
         )
         if clean:
             try:
-                resources = self.client_rds.describe_db_snapshots().get("DBSnapshots")
+                resources = self.client_rds.describe_db_snapshots(
+                    SnapshotType="manual"
+                ).get("DBSnapshots")
             except:
                 self.logging.error("Could not list all RDS Snapshots.")
                 self.logging.error(sys.exc_info()[1])

--- a/app/src/rds_cleanup.py
+++ b/app/src/rds_cleanup.py
@@ -71,11 +71,6 @@ class RDSCleanup:
                                         DBInstanceIdentifier=resource_id,
                                         DeletionProtection=False,
                                     )
-
-                                    self.logging.info(
-                                        f"RDS Instance '{resource_id}' had delete protection turned on "
-                                        "and now has been turned off."
-                                    )
                                 except:
                                     self.logging.error(
                                         f"Could not remove termination protection from RDS Instance '{resource_id}'."
@@ -83,6 +78,11 @@ class RDSCleanup:
                                     self.logging.error(sys.exc_info()[1])
                                     resource_action = "error"
                                     continue
+                                else:
+                                    self.logging.info(
+                                        f"RDS Instance '{resource_id}' had delete protection turned on "
+                                        "and now has been turned off."
+                                    )
 
                             # delete instance
                             try:

--- a/app/src/rds_cleanup.py
+++ b/app/src/rds_cleanup.py
@@ -33,6 +33,8 @@ class RDSCleanup:
         and then the Instance will be terminated.
         """
 
+        self.logging.debug("Started cleanup of RDS Instances.")
+
         clean = (
             self.settings.get("services", {})
             .get("rds", {})
@@ -126,6 +128,8 @@ class RDSCleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of RDS Instances.")
             return True
         else:
             self.logging.info("Skipping cleanup of RDS Instances.")
@@ -135,6 +139,8 @@ class RDSCleanup:
         """
         Deletes RDS Snapshots.
         """
+
+        self.logging.debug("Started cleanup of RDS Snapshots.")
 
         clean = (
             self.settings.get("services", {})
@@ -209,6 +215,8 @@ class RDSCleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of RDS Snapshots.")
             return True
         else:
             self.logging.debug("Skipping cleanup of RDS Snapshots.")

--- a/app/src/redshift_cleanup.py
+++ b/app/src/redshift_cleanup.py
@@ -90,7 +90,7 @@ class RedshiftCleanup:
                             self.logging.warn(
                                 f"Redshift Cluster '{resource_id}' in state '{resource_status}' cannot be deleted."
                             )
-                            resource_action = "warn"
+                            resource_action = "skip - in use"
                     else:
                         self.logging.debug(
                             f"Redshift Cluster '{resource_id}' was created {delta.days} days ago "
@@ -180,10 +180,10 @@ class RedshiftCleanup:
                             )
                             resource_action = "delete"
                         else:
-                            self.logging.error(
+                            self.logging.warn(
                                 f"Redshift Snapshot '{resource_id}' in state '{resource_status}' cannot be deleted."
                             )
-                            resource_action = "error"
+                            resource_action = "skip - in use"
                     else:
                         self.logging.debug(
                             f"Redshift Snapshot '{resource_id}' was created {delta.days} days ago "

--- a/app/src/redshift_cleanup.py
+++ b/app/src/redshift_cleanup.py
@@ -31,6 +31,8 @@ class RedshiftCleanup:
         Deletes Redshift Clusters.
         """
 
+        self.logging.debug("Started cleanup of Redshift Clusters.")
+
         clean = (
             self.settings.get("services", {})
             .get("redshift", {})
@@ -114,6 +116,8 @@ class RedshiftCleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of Redshift Clusters.")
             return True
         else:
             self.logging.info("Skipping cleanup of Redshift Clusters.")
@@ -123,6 +127,8 @@ class RedshiftCleanup:
         """
         Deletes Redshift Snapshots.
         """
+
+        self.logging.debug("Started cleanup of Redshift Snapshots.")
 
         clean = (
             self.settings.get("services", {})
@@ -207,6 +213,8 @@ class RedshiftCleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of Redshift Snapshots.")
             return True
         else:
             self.logging.info("Skipping cleanup of Redshift Snapshots.")

--- a/app/src/redshift_cleanup.py
+++ b/app/src/redshift_cleanup.py
@@ -87,10 +87,10 @@ class RedshiftCleanup:
                             )
                             resource_action = "delete"
                         else:
-                            self.logging.error(
+                            self.logging.warn(
                                 f"Redshift Cluster '{resource_id}' in state '{resource_status}' cannot be deleted."
                             )
-                            resource_action = "error"
+                            resource_action = "warn"
                     else:
                         self.logging.debug(
                             f"Redshift Cluster '{resource_id}' was created {delta.days} days ago "
@@ -132,9 +132,9 @@ class RedshiftCleanup:
         )
         if clean:
             try:
-                resources = self.client_redshift.describe_cluster_snapshots().get(
-                    "Snapshots"
-                )
+                resources = self.client_redshift.describe_cluster_snapshots(
+                    SnapshotType="manual",
+                ).get("Snapshots")
             except:
                 self.logging.error("Could not list all Redshift Snapshots.")
                 self.logging.error(sys.exc_info()[1])

--- a/app/src/s3_cleanup.py
+++ b/app/src/s3_cleanup.py
@@ -38,6 +38,8 @@ class S3Cleanup:
         are first deleted before the Bucket can be deleted.
         """
 
+        self.logging.debug("Started cleanup of S3 Buckets.")
+
         clean = (
             self.settings.get("services", {})
             .get("s3", {})
@@ -152,6 +154,8 @@ class S3Cleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of S3 Buckets.")
             return True
         else:
             self.logging.info("Skipping cleanup of S3 Buckets.")

--- a/app/src/sagemaker_cleanup.py
+++ b/app/src/sagemaker_cleanup.py
@@ -155,8 +155,10 @@ class SageMakerCleanup:
                     delta = Helper.get_day_delta(resource_date)
 
                     if delta.days > ttl_days:
-                        if not self.settings.get("general", {}).get("dry_run", True):
-                            if resource_status == "InService":
+                        if resource_status == "InService":
+                            if not self.settings.get("general", {}).get(
+                                "dry_run", True
+                            ):
                                 try:
                                     self.client_sagemaker.stop_notebook_instance(
                                         NotebookInstanceName=resource_id,
@@ -168,13 +170,16 @@ class SageMakerCleanup:
                                     self.logging.error(sys.exc_info()[1])
                                     resource_action = "error"
                                     continue
-                                else:
-                                    self.logging.info(
-                                        f"SageMaker Notebook Instance '{resource_id}' was last modified {delta.days} days ago "
-                                        "and has been stopped."
-                                    )
-                                    resource_action = "stop"
-                            elif resource_status in ("Stopped", "Failed"):
+
+                            self.logging.info(
+                                f"SageMaker Notebook Instance '{resource_id}' was last modified {delta.days} days ago "
+                                "and has been stopped."
+                            )
+                            resource_action = "stop"
+                        elif resource_status in ("Stopped", "Failed"):
+                            if not self.settings.get("general", {}).get(
+                                "dry_run", True
+                            ):
                                 try:
                                     self.client_sagemaker.delete_notebook_instance(
                                         NotebookInstanceName=resource_id,
@@ -186,12 +191,12 @@ class SageMakerCleanup:
                                     self.logging.error(sys.exc_info()[1])
                                     resource_action = "error"
                                     continue
-                                else:
-                                    self.logging.info(
-                                        f"SageMaker Notebook Instance '{resource_id}' was last modified {delta.days} days ago "
-                                        "and has been deleted."
-                                    )
-                                    resource_action = "delete"
+
+                            self.logging.info(
+                                f"SageMaker Notebook Instance '{resource_id}' was last modified {delta.days} days ago "
+                                "and has been deleted."
+                            )
+                            resource_action = "delete"
                     else:
                         self.logging.debug(
                             f"SageMaker Notebook Instance '{resource_id}' was created {delta.days} days ago "

--- a/app/src/sagemaker_cleanup.py
+++ b/app/src/sagemaker_cleanup.py
@@ -100,8 +100,8 @@ class SageMakerCleanup:
                     resource_action = "skip - whitelist"
 
                 self.execution_log.get("AWS").setdefault(self.region, {}).setdefault(
-                    "sagemaker", {}
-                ).setdefault("endpoint", []).append(
+                    "SageMaker", {}
+                ).setdefault("Endpoint", []).append(
                     {
                         "id": resource_id,
                         "action": resource_action,
@@ -205,8 +205,8 @@ class SageMakerCleanup:
                     resource_action = "skip - whitelist"
 
                 self.execution_log.get("AWS").setdefault(self.region, {}).setdefault(
-                    "sagemaker", {}
-                ).setdefault("notebook_instance", []).append(
+                    "SageMaker", {}
+                ).setdefault("Notebook Instance", []).append(
                     {
                         "id": resource_id,
                         "action": resource_action,

--- a/app/src/sagemaker_cleanup.py
+++ b/app/src/sagemaker_cleanup.py
@@ -31,6 +31,8 @@ class SageMakerCleanup:
         Deletes SageMaker Endpoints.
         """
 
+        self.logging.debug("Started cleanup of SageMaker Endpoints.")
+
         clean = (
             self.settings.get("services", {})
             .get("sagemaker", {})
@@ -110,6 +112,8 @@ class SageMakerCleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of SageMaker Endpoints.")
             return True
         else:
             self.logging.info("Skipping cleanup of SageMaker Endpoints.")
@@ -119,6 +123,8 @@ class SageMakerCleanup:
         """
         Deletes SageMaker Notebook Instances.
         """
+
+        self.logging.debug("Started cleanup of SageMaker Notebook Instances.")
 
         clean = (
             self.settings.get("services", {})
@@ -220,6 +226,8 @@ class SageMakerCleanup:
                         ),
                     }
                 )
+
+            self.logging.debug("Finished cleanup of SageMaker Notebook Instances.")
             return True
         else:
             self.logging.info("Skipping cleanup of SageMaker Notebook Instances.")

--- a/web/README.md
+++ b/web/README.md
@@ -30,7 +30,7 @@ The Auto Cleanup Website is a static Vue.js website hosted within Amazon S3. The
 4. Deploy website
 
    ```bash
-   npm run deploy-client -- [--region] [--aws-profile]
+   npm run deploy:client -- [--region] [--aws-profile]
    ```
 
 ## Removal
@@ -44,7 +44,7 @@ The Auto Cleanup Website is a static Vue.js website hosted within Amazon S3. The
 2. Remove website
 
    ```bash
-   npm run remove-client -- [--region] [--aws-profile]
+   npm run remove:client -- [--region] [--aws-profile]
    ```
 
 3. Remove infrastructure

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-cleanup-web",
   "description": "Auto Cleanup Web",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "dependencies": {},
   "devDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "deploy": "serverless deploy",
     "remove": "serverless remove",
-    "deploy-client": "serverless client deploy --no-confirm",
-    "remove-client": "serverless client remove"
+    "deploy:client": "serverless client deploy --no-confirm",
+    "remove:client": "serverless client remove"
   }
 }

--- a/web/src/css/style.css
+++ b/web/src/css/style.css
@@ -12,6 +12,7 @@ table.table {
 
 .execution-log-modal {
   width: calc(100vw - 40px) !important;
+  height: calc(100vh - 40px) !important;
 }
 
 .execution-log-modal .table {

--- a/web/src/css/style.css
+++ b/web/src/css/style.css
@@ -2,41 +2,12 @@ html {
   background: #fafafa;
 }
 
-.navbar {
-  background: #232f3e;
-}
-
-.navbar-brand {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-.navbar h1 {
-  color: #d5dbdb;
-  font-family: "Amazon Ember", "Helvetica Neue", Roboto, Arial, sans-serif;
-  font-size: 14px;
-  line-height: 1;
-  font-weight: bold;
-}
-
-.navbar img {
-  padding-left: 28px;
-  margin-right: 6px;
-  height: 20px;
-}
-
 .body-container {
   margin: 50px auto;
 }
 
 table.table {
   width: 100%;
-}
-
-.add-btn-wrap {
-  text-align: center;
-  margin: 50px 0;
 }
 
 .execution-log-modal {

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -230,47 +230,71 @@
                 style="line-height: unset !important"
               >
                 <button
-                  v-if="executionLogMode === 'Destroy'"
                   class="button is-danger"
+                  v-if="executionLogMode === 'Destroy'"
                 >
                   <span>{{executionLogMode}}</span>
                 </button>
                 <button
-                  v-if="executionLogMode === 'Dry Run'"
                   class="button is-success"
+                  v-if="executionLogMode === 'Dry Run'"
                 >
                   <span>{{executionLogMode}}</span>
                 </button>
                 <span>{{executionLogKey}}</span>
               </p>
               <button
-                class="delete"
                 aria-label="close"
+                class="delete"
                 v-on:click="closeExecutionLogPopup()"
               ></button>
             </header>
             <div class="box" style="border-radius: 0px !important">
               <div class="content">
-                <div class="tabs is-toggle">
-                  <ul style="margin: 0px !important">
-                    <li class="tab is-active" onclick="openTab(event,'logs')">
-                      <a>
-                        <span class="icon is-small"
-                          ><i class="fas fa-bars" aria-hidden="true"></i
-                        ></span>
-                        <span>Logs</span>
-                      </a>
-                    </li>
-                    <li class="tab" onclick="openTab(event,'statistics')">
-                      <a>
-                        <span class="icon is-small"
-                          ><i class="far fa-chart-bar" aria-hidden="true"></i
-                        ></span>
-                        <span>Statistics</span>
-                      </a>
-                    </li>
-                  </ul>
-                </div>
+                <nav class="level">
+                  <div class="level-left">
+                    <div class="tabs is-toggle">
+                      <ul style="margin: 0px !important">
+                        <li
+                          class="tab is-active"
+                          onclick="openTab(event,'logs')"
+                        >
+                          <a>
+                            <span class="icon is-small"
+                              ><i class="fas fa-bars" aria-hidden="true"></i
+                            ></span>
+                            <span>Logs</span>
+                          </a>
+                        </li>
+                        <li class="tab" onclick="openTab(event,'statistics')">
+                          <a>
+                            <span class="icon is-small"
+                              ><i
+                                class="far fa-chart-bar"
+                                aria-hidden="true"
+                              ></i
+                            ></span>
+                            <span>Statistics</span>
+                          </a>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                  <div class="level-right">
+                    <div class="control has-icons-left is-right">
+                      <input
+                        class="input"
+                        placeholder="Search"
+                        type="text"
+                        v-model="executionLogSearchTerm"
+                        v-on:keyup="executionLogSearch()"
+                      />
+                      <span class="icon is-left">
+                        <i class="fas fa-search"></i>
+                      </span>
+                    </div>
+                  </div>
+                </nav>
                 <div class="container is-fluid" style="padding: 0px !important">
                   <div id="logs" class="content-tab">
                     <table class="table" id="execution-log-table">

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -250,84 +250,112 @@
             </header>
             <div class="box" style="border-radius: 0px !important">
               <div class="content">
-                <h2>Log</h2>
-                <table class="table" id="execution-log-table">
-                  <thead>
-                    <tr>
-                      <th>Timestamp</th>
-                      <th>Region</th>
-                      <th>Service</th>
-                      <th>Resource</th>
-                      <th>ID</th>
-                      <th>Action</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr v-for="item in executionLogTable" :key="item.id">
-                      <td style="white-space: nowrap">{{ item[6] }}</td>
-                      <td style="white-space: nowrap">{{ item[1] }}</td>
-                      <td style="white-space: nowrap">{{ item[2] }}</td>
-                      <td style="white-space: nowrap">{{ item[3] }}</td>
-                      <td>{{ item[4] }}</td>
-                      <td style="white-space: nowrap">{{ item[5] }}</td>
-                    </tr>
-                  </tbody>
-                </table>
-                <h2>Statistics</h2>
-                <div class="columns">
-                  <div class="column">
+                <div class="tabs is-toggle">
+                  <ul style="margin: 0px !important">
+                    <li class="tab is-active" onclick="openTab(event,'logs')">
+                      <a>
+                        <span class="icon is-small"
+                          ><i class="fas fa-bars" aria-hidden="true"></i
+                        ></span>
+                        <span>Logs</span>
+                      </a>
+                    </li>
+                    <li class="tab" onclick="openTab(event,'statistics')">
+                      <a>
+                        <span class="icon is-small"
+                          ><i class="far fa-chart-bar" aria-hidden="true"></i
+                        ></span>
+                        <span>Statistics</span>
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+                <div class="container is-fluid" style="padding: 0px !important">
+                  <div id="logs" class="content-tab">
                     <table class="table" id="execution-log-table">
                       <thead>
                         <tr>
-                          <th>Resource</th>
-                          <th>Count</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <tr
-                          v-for="key in Object.keys(executionLogServiceStats).sort()"
-                        >
-                          <td style="white-space: nowrap">{{key}}</td>
-                          <td>{{executionLogServiceStats[key]}}</td>
-                        </tr>
-                      </tbody>
-                    </table>
-                  </div>
-                  <div class="column">
-                    <table class="table" id="execution-log-table">
-                      <thead>
-                        <tr>
-                          <th>Action</th>
-                          <th>Count</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <tr
-                          v-for="key in Object.keys(executionLogActionStats).sort()"
-                        >
-                          <td style="white-space: nowrap">{{key}}</td>
-                          <td>{{executionLogActionStats[key]}}</td>
-                        </tr>
-                      </tbody>
-                    </table>
-                  </div>
-                  <div class="column">
-                    <table class="table" id="execution-log-table">
-                      <thead>
-                        <tr>
+                          <th>Timestamp</th>
                           <th>Region</th>
-                          <th>Count</th>
+                          <th>Service</th>
+                          <th>Resource</th>
+                          <th>ID</th>
+                          <th>Action</th>
                         </tr>
                       </thead>
                       <tbody>
-                        <tr
-                          v-for="key in Object.keys(executionLogRegionStats).sort()"
-                        >
-                          <td style="white-space: nowrap">{{key}}</td>
-                          <td>{{executionLogRegionStats[key]}}</td>
+                        <tr v-for="item in executionLogTable" :key="item.id">
+                          <td style="white-space: nowrap">{{ item[6] }}</td>
+                          <td style="white-space: nowrap">{{ item[1] }}</td>
+                          <td style="white-space: nowrap">{{ item[2] }}</td>
+                          <td style="white-space: nowrap">{{ item[3] }}</td>
+                          <td>{{ item[4] }}</td>
+                          <td style="white-space: nowrap">{{ item[5] }}</td>
                         </tr>
                       </tbody>
                     </table>
+                  </div>
+                  <div
+                    id="statistics"
+                    class="content-tab"
+                    style="display: none"
+                  >
+                    <div class="columns">
+                      <div class="column">
+                        <table class="table" id="execution-log-table">
+                          <thead>
+                            <tr>
+                              <th>Resource</th>
+                              <th>Count</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr
+                              v-for="key in Object.keys(executionLogServiceStats).sort()"
+                            >
+                              <td style="white-space: nowrap">{{key}}</td>
+                              <td>{{executionLogServiceStats[key]}}</td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </div>
+                      <div class="column">
+                        <table class="table" id="execution-log-table">
+                          <thead>
+                            <tr>
+                              <th>Action</th>
+                              <th>Count</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr
+                              v-for="key in Object.keys(executionLogActionStats).sort()"
+                            >
+                              <td style="white-space: nowrap">{{key}}</td>
+                              <td>{{executionLogActionStats[key]}}</td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </div>
+                      <div class="column">
+                        <table class="table" id="execution-log-table">
+                          <thead>
+                            <tr>
+                              <th>Region</th>
+                              <th>Count</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr
+                              v-for="key in Object.keys(executionLogRegionStats).sort()"
+                            >
+                              <td style="white-space: nowrap">{{key}}</td>
+                              <td>{{executionLogRegionStats[key]}}</td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -458,29 +458,22 @@
           <section class="modal-card-body">
             <div class="content">
               <p>
-                Open-source application to programmatically clean AWS resources
-                based on a Whitelist and time-to-live (TTL) settings.
+                AWS Auto Cleanup is an open-source application to
+                programmatically clean AWS resources based on a Whitelist and
+                time-to-live (TTL) settings.
               </p>
-              <h2>How Does it Work</h2>
+              <h2>Whitelist</h2>
               <p>
-                Every <i>n</i> number of days, AWS Auto Cleanup searches for AWS
-                resources that have been created or modified a number of days
-                ago. If the created or modified date is greater than the allowed
-                time-to-live (TTL), the resource will be deleted.
+                The whitelist maintains a record of all AWS resources that have
+                been preserved. During the execution of Auto Cleanup, the
+                scanned resources will be checked against the whitelist. If the
+                resource exists within the whitelist table, it will not be
+                deleted.
               </p>
+              <h2>Services</h2>
               <p>
-                To preserve resources beyond the pre-determined TTL, they can be
-                added to the Whitelist. Resources added to the Whitelist are not
-                permanently preserved; they receive an expiration date upon
-                creation. Once that expiration date passes, they will be
-                deleted. However, resources within the Whitelist can have their
-                expiration date extended whenever necessary.
-              </p>
-              <h2>Supported Services</h2>
-              <p>
-                The below table details the AWS services, resources, their
-                default TTLs, and whether that particular resource is monitored
-                and cleaned up.
+                The table below details AWS services, resources, default TTLs,
+                and whether that particular resource is monitored and cleaned.
               </p>
               <table class="table">
                 <thead>
@@ -500,6 +493,13 @@
                   </tr>
                 </tbody>
               </table>
+              <h2>Execution Log</h2>
+              <p>
+                Post every Auto Cleanup run, an execution log is generated and
+                stored as a flat CSV file within an S3 Bucket. The execution log
+                details the actions taken for each AWS service and resource that
+                was scanned and identified.
+              </p>
             </div>
           </section>
           <footer class="modal-card-foot">

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -71,11 +71,6 @@
     />
     <link
       rel="stylesheet"
-      href="//db.onlinewebfonts.com/c/157c6cc36dd65b1b2adc9e7f3329c761?family=Amazon+Ember"
-      type="text/css"
-    />
-    <link
-      rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/izitoast/1.4.0/css/iziToast.min.css"
       integrity="sha512-O03ntXoVqaGUTAeAmvQ2YSzkCvclZEcPQu1eqloPaHfJ5RuNGiS4l+3duaidD801P50J28EHyonCV06CUlTSag=="
       crossorigin="anonymous"
@@ -83,25 +78,47 @@
     <link rel="stylesheet" href="css/style.css" />
   </head>
   <body>
-    <!-- Header -->
-    <nav class="navbar" role="navigation" aria-label="main navigation">
-      <div class="navbar-brand">
-        <a class="navbar-item" href="#">
-          <img src="img/logo.svg" alt="AWS Auto Cleanup" style="height: 18px" />
-        </a>
-        <h1>AWS Auto Cleanup</h1>
-      </div>
-    </nav>
+    <div id="app">
+      <!-- Header -->
+      <nav
+        class="navbar is-dark"
+        role="navigation"
+        aria-label="main navigation"
+      >
+        <div class="navbar-brand">
+          <a class="navbar-item" href="">
+            <img src="img/logo.svg" style="height: 18px" />
+          </a>
+        </div>
 
-    <!-- Body -->
-    <div class="container body-container">
-      <div id="app">
+        <div id="navbarBasicExample" class="navbar-menu">
+          <div class="navbar-start">
+            <a class="navbar-item"> AWS Auto Cleanup </a>
+          </div>
+        </div>
+
+        <div class="navbar-end">
+          <div class="navbar-item">
+            <div class="buttons">
+              <button class="button is-light" v-on:click="openHelpPopup()">
+                <span class="icon">
+                  <i class="fas fa-question"></i>
+                </span>
+                <span>Help</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      <!-- Body -->
+      <div class="container body-container">
         <h2 class="title">
           Whitelist&nbsp;<button
             class="button is-warning"
             v-on:click="openWhitelistInsertPopup()"
           >
-            <span class="icon"> <i class="fas fa-plus-square"></i> </span>
+            <span class="icon"> <i class="fas fa-plus"></i> </span>
             <span>New Entry</span>
           </button>
         </h2>
@@ -128,7 +145,7 @@
                   class="button is-warning"
                 >
                   <span class="icon">
-                    <i class="fas fa-calendar-plus"></i>
+                    <i class="far fa-calendar-plus"></i>
                   </span>
                 </a>
                 <button
@@ -137,7 +154,7 @@
                   class="button is-danger"
                 >
                   <span class="icon">
-                    <i class="fas fa-minus-square"></i>
+                    <i class="far fa-trash-alt"></i>
                   </span>
                 </button>
               </td>
@@ -171,7 +188,7 @@
                   v-on:click="openExecutionLog( item.key_escape )"
                   target="_blank"
                   class="button"
-                  ><span class="icon"> <i class="fas fa-list-alt"></i> </span
+                  ><span class="icon"> <i class="fas fa-list"></i> </span
                 ></a>
               </td>
             </tr>
@@ -386,8 +403,8 @@
         <!-- Popup: Delete Whitelist Rule -->
         <div
           class="modal"
-          v-bind:class="{ 'is-active': showWhitelistDeletePopup }"
           id="delete-whitelist"
+          v-bind:class="{ 'is-active': showWhitelistDeletePopup }"
         >
           <div
             class="modal-background"
@@ -420,6 +437,76 @@
               </button>
             </footer>
           </div>
+        </div>
+      </div>
+
+      <div
+        class="modal"
+        id="help"
+        v-bind:class="{ 'is-active': showHelpPopup }"
+      >
+        <div class="modal-background" v-on:click="closeHelpPopup()"></div>
+        <div class="modal-card">
+          <header class="modal-card-head">
+            <p class="modal-card-title">AWS Auto Cleanup Help</p>
+            <button
+              class="delete"
+              aria-label="close"
+              v-on:click="closeHelpPopup()"
+            ></button>
+          </header>
+          <section class="modal-card-body">
+            <div class="content">
+              <p>
+                Open-source application to programmatically clean AWS resources
+                based on a Whitelist and time-to-live (TTL) settings.
+              </p>
+              <h2>How Does it Work</h2>
+              <p>
+                Every <i>n</i> number of days, AWS Auto Cleanup searches for AWS
+                resources that have been created or modified a number of days
+                ago. If the created or modified date is greater than the allowed
+                time-to-live (TTL), the resource will be deleted.
+              </p>
+              <p>
+                To preserve resources beyond the pre-determined TTL, they can be
+                added to the Whitelist. Resources added to the Whitelist are not
+                permanently preserved; they receive an expiration date upon
+                creation. Once that expiration date passes, they will be
+                deleted. However, resources within the Whitelist can have their
+                expiration date extended whenever necessary.
+              </p>
+              <h2>Supported Services</h2>
+              <p>
+                The below table details the AWS services, resources, their
+                default TTLs, and whether that particular resource is monitored
+                and cleaned up.
+              </p>
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th>Service</th>
+                    <th>Resource</th>
+                    <th>TTL (days)</th>
+                    <th>Enabled</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="item in settingsFlat">
+                    <td>{{ item.service }}</td>
+                    <td>{{ item.resource }}</td>
+                    <td>{{ item.ttl }}</td>
+                    <td>{{ item.enabled }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+          <footer class="modal-card-foot">
+            <button class="button is-success" v-on:click="closeHelpPopup()">
+              OK
+            </button>
+          </footer>
         </div>
       </div>
     </div>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -100,7 +100,13 @@
         <div class="navbar-end">
           <div class="navbar-item">
             <div class="buttons">
-              <button class="button is-light" v-on:click="openHelpPopup()">
+              <button class="button is-light">
+                <span class="icon">
+                  <i class="fab fa-aws"></i>
+                </span>
+                <span>{{accountId}}</span>
+              </button>
+              <button class="button is-info" v-on:click="openHelpPopup()">
                 <span class="icon">
                   <i class="fas fa-question"></i>
                 </span>
@@ -485,7 +491,7 @@
                   </tr>
                 </thead>
                 <tbody>
-                  <tr v-for="item in settingsFlat">
+                  <tr v-for="item in serviceSettingsFlat">
                     <td>{{ item.service }}</td>
                     <td>{{ item.resource }}</td>
                     <td>{{ item.ttl }}</td>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -100,7 +100,16 @@
         <div class="navbar-end">
           <div class="navbar-item">
             <div class="buttons">
-              <button class="button is-light">
+              <a
+                class="button is-light"
+                href="https://github.com/servian/aws-auto-cleanup/"
+              >
+                <span class="icon">
+                  <i class="fab fa-github"></i>
+                </span>
+                <span>servian/aws-auto-cleanup</span>
+              </a>
+              <button class="button is-static">
                 <span class="icon">
                   <i class="fab fa-aws"></i>
                 </span>
@@ -633,16 +642,10 @@
     </div>
 
     <!-- Footer -->
-    <footer class="footer">
+    <!-- <footer class="footer">
       <div class="content has-text-centered">
-        <a class="button" href="https://github.com/servian/aws-auto-cleanup/">
-          <span class="icon">
-            <i class="fab fa-github"></i>
-          </span>
-          <span>servian/aws-auto-cleanup</span>
-        </a>
       </div>
-    </footer>
+    </footer> -->
 
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.12/vue.min.js"

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -196,7 +196,8 @@
                   v-on:click="openExecutionLog( item.key_escape )"
                   target="_blank"
                   class="button"
-                  ><span class="icon"> <i class="fas fa-list"></i> </span
+                  ><span class="icon">
+                    <i class="fas fa-external-link-alt"></i> </span
                 ></a>
               </td>
             </tr>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -181,7 +181,7 @@
 
         <table class="table" id="execution-log-list-table">
           <thead>
-            <th>Key</th>
+            <th>Log</th>
             <th>Date</th>
             <th>View</th>
           </thead>
@@ -247,33 +247,75 @@
               ></button>
             </header>
             <div class="box" style="border-radius: 0px !important">
-              <table class="table" id="execution-log-table">
-                <thead>
-                  <tr>
-                    <th>Timestamp</th>
-                    <th>Region</th>
-                    <th>Service</th>
-                    <th>Resource</th>
-                    <th>ID</th>
-                    <th>Action</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr v-for="item in executionLogTable" :key="item.id">
-                    <td>{{ item[6] }}</td>
-                    <td>{{ item[1] }}</td>
-                    <td>{{ item[2] }}</td>
-                    <td>{{ item[3] }}</td>
-                    <td>{{ item[4] }}</td>
-                    <td>{{ item[5] }}</td>
-                  </tr>
-                </tbody>
-              </table>
-              <div
-                class="container has-text-centered"
-                v-show="showExecutionLogLoadingGif"
-              >
-                <button class="button is-warning is-loading">Loading</button>
+              <div class="content">
+                <h2>Log</h2>
+                <table class="table" id="execution-log-table">
+                  <thead>
+                    <tr>
+                      <th>Timestamp</th>
+                      <th>Region</th>
+                      <th>Service</th>
+                      <th>Resource</th>
+                      <th>ID</th>
+                      <th>Action</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="item in executionLogTable" :key="item.id">
+                      <td>{{ item[6] }}</td>
+                      <td>{{ item[1] }}</td>
+                      <td>{{ item[2] }}</td>
+                      <td>{{ item[3] }}</td>
+                      <td>{{ item[4] }}</td>
+                      <td>{{ item[5] }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+                <h2>Statistics</h2>
+                <div class="columns">
+                  <div class="column">
+                    <table class="table" id="execution-log-table">
+                      <thead>
+                        <tr>
+                          <th>Resource</th>
+                          <th>Count</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr
+                          v-for="key in Object.keys(executionLogServicetats).sort()"
+                        >
+                          <td>{{key}}</td>
+                          <td>{{executionLogServicetats[key]}}</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                  <div class="column">
+                    <table class="table" id="execution-log-table">
+                      <thead>
+                        <tr>
+                          <th>Action</th>
+                          <th>Count</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr
+                          v-for="key in Object.keys(executionLogActionStats).sort()"
+                        >
+                          <td>{{key}}</td>
+                          <td>{{executionLogActionStats[key]}}</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+                <div
+                  class="container has-text-centered"
+                  v-show="showExecutionLogLoadingGif"
+                >
+                  <button class="button is-warning is-loading">Loading</button>
+                </div>
               </div>
             </div>
             <!-- .box -->

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -283,10 +283,10 @@
                       </thead>
                       <tbody>
                         <tr
-                          v-for="key in Object.keys(executionLogServicetats).sort()"
+                          v-for="key in Object.keys(executionLogServiceStats).sort()"
                         >
                           <td>{{key}}</td>
-                          <td>{{executionLogServicetats[key]}}</td>
+                          <td>{{executionLogServiceStats[key]}}</td>
                         </tr>
                       </tbody>
                     </table>
@@ -305,6 +305,24 @@
                         >
                           <td>{{key}}</td>
                           <td>{{executionLogActionStats[key]}}</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                  <div class="column">
+                    <table class="table" id="execution-log-table">
+                      <thead>
+                        <tr>
+                          <th>Region</th>
+                          <th>Count</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr
+                          v-for="key in Object.keys(executionLogRegionStats).sort()"
+                        >
+                          <td>{{key}}</td>
+                          <td>{{executionLogRegionStats[key]}}</td>
                         </tr>
                       </tbody>
                     </table>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -128,15 +128,33 @@
 
       <!-- Body -->
       <div class="container body-container">
-        <h2 class="title">
-          Whitelist&nbsp;<button
-            class="button is-warning"
-            v-on:click="openWhitelistInsertPopup()"
-          >
-            <span class="icon"> <i class="fas fa-plus"></i> </span>
-            <span>New Entry</span>
-          </button>
-        </h2>
+        <nav class="level">
+          <div class="level-left">
+            <h3 class="title is-3 mb-0 mr-2">Whitelist</h3>
+            <!-- <h2 class="title">Whitelist</h2> -->
+            <button
+              class="button is-warning"
+              v-on:click="openWhitelistInsertPopup()"
+            >
+              <span class="icon"> <i class="fas fa-plus"></i> </span>
+              <span>New Entry</span>
+            </button>
+          </div>
+          <div class="level-right">
+            <div class="control has-icons-left is-right">
+              <input
+                class="input"
+                placeholder="Search"
+                type="text"
+                v-model="whitelistSearchTerm"
+                v-on:keyup="searchWhitelist()"
+              />
+              <span class="icon is-left">
+                <i class="fas fa-search"></i>
+              </span>
+            </div>
+          </div>
+        </nav>
         <table class="table" id="whitelist">
           <thead>
             <tr>
@@ -188,7 +206,26 @@
         <br />
 
         <!-- Execution Log -->
-        <h2 class="title">Execution Logs</h2>
+        <!-- <h2 class="title"></h2> -->
+        <nav class="level">
+          <div class="level-left">
+            <h3 class="title is-3 mt-2 mb-0 mr-2">Execution Logs</h3>
+          </div>
+          <!-- <div class="level-right">
+            <div class="control has-icons-left is-right">
+              <input
+                class="input"
+                placeholder="Search"
+                type="text"
+                v-model="executionLogSearchTerm"
+                v-on:keyup="searchExecutionLog()"
+              />
+              <span class="icon is-left">
+                <i class="fas fa-search"></i>
+              </span>
+            </div>
+          </div> -->
+        </nav>
 
         <table class="table" id="execution-log-list-table">
           <thead>
@@ -263,7 +300,7 @@
                 <nav class="level">
                   <div class="level-left">
                     <div class="tabs is-toggle">
-                      <ul style="margin: 0px !important">
+                      <ul class="m-0">
                         <li
                           class="tab is-active"
                           onclick="openTab(event,'logs')"
@@ -296,7 +333,7 @@
                         placeholder="Search"
                         type="text"
                         v-model="executionLogSearchTerm"
-                        v-on:keyup="executionLogSearch()"
+                        v-on:keyup="searchExecutionLog()"
                       />
                       <span class="icon is-left">
                         <i class="fas fa-search"></i>
@@ -304,7 +341,7 @@
                     </div>
                   </div>
                 </nav>
-                <div class="container is-fluid" style="padding: 0px !important">
+                <div class="container is-fluid p-0">
                   <div id="logs" class="content-tab">
                     <table class="table" id="execution-log-table">
                       <thead>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -140,11 +140,13 @@
           </thead>
           <tbody>
             <tr v-for="item in whitelist" :key="item.id">
-              <td>{{ item.resource_id }}</td>
-              <td>{{ item.expiration_readable }}</td>
-              <td>{{ item.owner }}</td>
+              <td style="white-space: nowrap">{{ item.resource_id }}</td>
+              <td style="white-space: nowrap">
+                {{ item.expiration_readable }}
+              </td>
+              <td style="white-space: nowrap">{{ item.owner }}</td>
               <td>{{ item.comment }}</td>
-              <td>
+              <td style="white-space: nowrap">
                 <a
                   v-if="item.expiration !== '99999999999'"
                   v-on:click="extendWhitelistEntry( item.id )"
@@ -262,12 +264,12 @@
                   </thead>
                   <tbody>
                     <tr v-for="item in executionLogTable" :key="item.id">
-                      <td>{{ item[6] }}</td>
-                      <td>{{ item[1] }}</td>
-                      <td>{{ item[2] }}</td>
-                      <td>{{ item[3] }}</td>
+                      <td style="white-space: nowrap">{{ item[6] }}</td>
+                      <td style="white-space: nowrap">{{ item[1] }}</td>
+                      <td style="white-space: nowrap">{{ item[2] }}</td>
+                      <td style="white-space: nowrap">{{ item[3] }}</td>
                       <td>{{ item[4] }}</td>
-                      <td>{{ item[5] }}</td>
+                      <td style="white-space: nowrap">{{ item[5] }}</td>
                     </tr>
                   </tbody>
                 </table>
@@ -285,7 +287,7 @@
                         <tr
                           v-for="key in Object.keys(executionLogServiceStats).sort()"
                         >
-                          <td>{{key}}</td>
+                          <td style="white-space: nowrap">{{key}}</td>
                           <td>{{executionLogServiceStats[key]}}</td>
                         </tr>
                       </tbody>
@@ -303,7 +305,7 @@
                         <tr
                           v-for="key in Object.keys(executionLogActionStats).sort()"
                         >
-                          <td>{{key}}</td>
+                          <td style="white-space: nowrap">{{key}}</td>
                           <td>{{executionLogActionStats[key]}}</td>
                         </tr>
                       </tbody>
@@ -321,7 +323,7 @@
                         <tr
                           v-for="key in Object.keys(executionLogRegionStats).sort()"
                         >
-                          <td>{{key}}</td>
+                          <td style="white-space: nowrap">{{key}}</td>
                           <td>{{executionLogRegionStats[key]}}</td>
                         </tr>
                       </tbody>

--- a/web/src/js/index.js
+++ b/web/src/js/index.js
@@ -22,7 +22,8 @@ var app = new Vue({
     executionLogKey: "",
     executionLogList: [],
     executionLogMode: "",
-    executionLogServicetats: {},
+    executionLogRegionStats: {},
+    executionLogServiceStats: {},
     executionLogTable: [],
     resourceIdPlaceholder: "",
     resourceList: [],
@@ -118,7 +119,8 @@ var app = new Vue({
     closeExecutionLogPopup: function () {
       $("#execution-log-table").DataTable().destroy();
       this.executionLogActionStats = {};
-      this.executionLogServicetats = {};
+      this.executionLogRegionStats = {};
+      this.executionLogServiceStats = {};
       this.showExecutionLogPopup = false;
     },
     // Help
@@ -191,11 +193,17 @@ function getExecutionLog(executionLogURL) {
       }
 
       for (log of data["response"]["body"]) {
+        // action taken
         app.executionLogActionStats[log["5"]] =
           ++app.executionLogActionStats[log["5"]] || 1;
 
-        app.executionLogServicetats[log["2"] + " " + log["3"]] =
-          ++app.executionLogServicetats[log["2"] + " " + log["3"]] || 1;
+        // service and resource
+        app.executionLogServiceStats[log["2"] + " " + log["3"]] =
+          ++app.executionLogServiceStats[log["2"] + " " + log["3"]] || 1;
+
+        // region
+        app.executionLogRegionStats[log["1"]] =
+          ++app.executionLogRegionStats[log["1"]] || 1;
       }
     })
     .catch((error) => {

--- a/web/src/js/index.js
+++ b/web/src/js/index.js
@@ -160,7 +160,6 @@ function getExecutionLog(executionLogURL) {
 
       setTimeout(function () {
         $("#execution-log-table").DataTable({
-          paging: false,
           autoWidth: true,
           columnDefs: [
             {
@@ -169,6 +168,7 @@ function getExecutionLog(executionLogURL) {
             },
             { className: "dt-nowrap", targets: [1, 2, 3, 5] },
           ],
+          paging: false,
         });
         app.showExecutionLogLoadingGif = false;
       }, 10);
@@ -199,6 +199,7 @@ function getExecutionLogList() {
             { orderable: false, targets: [2] },
             { className: "dt-center", targets: [2] },
           ],
+          order: [[0, "desc"]],
         });
       }, 10);
       app.showExecutionLogListLoadingGif = false;

--- a/web/src/js/index.js
+++ b/web/src/js/index.js
@@ -23,8 +23,10 @@ var app = new Vue({
     executionLogList: [],
     executionLogMode: "",
     executionLogRegionStats: {},
+    executionLogSearchTerm: "",
     executionLogServiceStats: {},
     executionLogTable: [],
+    executionLogDataTables: "",
     resourceIdPlaceholder: "",
     resourceList: [],
     selectedComment: "",
@@ -113,15 +115,19 @@ var app = new Vue({
       this.resourceIdPlaceholder = "";
     },
     // Execution Log
-    openExecutionLog: function (keyURL) {
-      getExecutionLog(keyURL);
-    },
     closeExecutionLogPopup: function () {
-      $("#execution-log-table").DataTable().destroy();
+      this.executionLogDataTables.destroy();
+
       this.executionLogActionStats = {};
       this.executionLogRegionStats = {};
       this.executionLogServiceStats = {};
       this.showExecutionLogPopup = false;
+    },
+    executionLogSearch: function () {
+      this.executionLogDataTables.search(this.executionLogSearchTerm).draw();
+    },
+    openExecutionLog: function (keyURL) {
+      getExecutionLog(keyURL);
     },
     // Help
     closeHelpPopup: function () {
@@ -171,7 +177,8 @@ function getExecutionLog(executionLogURL) {
       app.executionLogKey = decodeURIComponent(executionLogURL);
 
       setTimeout(function () {
-        $("#execution-log-table").DataTable({
+        app.executionLogDataTables = $("#execution-log-table").DataTable({
+          dom: "lrti",
           autoWidth: true,
           paging: false,
         });

--- a/web/src/js/index.js
+++ b/web/src/js/index.js
@@ -234,7 +234,6 @@ function getSettings() {
       // console.log(data["response"]);
 
       for (service in data["response"]) {
-        console.log(service);
         for (resource in data["response"][service]) {
           app.settingsFlat.push({
             service: service,

--- a/web/src/js/index.js
+++ b/web/src/js/index.js
@@ -31,10 +31,12 @@ var app = new Vue({
     selectedService: "",
     serviceList: [],
     settings: [],
-    showWhitelistDeletePopup: false,
+    settingsFlat: [],
     showExecutionLogListLoadingGif: false,
     showExecutionLogLoadingGif: false,
     showExecutionLogPopup: false,
+    showHelpPopup: false,
+    showWhitelistDeletePopup: false,
     showWhitelistLoadingGif: false,
     showWhitelistPopup: false,
     whitelist: [],
@@ -111,6 +113,13 @@ var app = new Vue({
     closeExecutionLogPopup: function () {
       $("#execution-log-table").DataTable().destroy();
       this.showExecutionLogPopup = false;
+    },
+    // Help
+    closeHelpPopup: function () {
+      this.showHelpPopup = false;
+    },
+    openHelpPopup: function () {
+      this.showHelpPopup = true;
     },
   },
 });
@@ -221,12 +230,27 @@ function getSettings() {
     .then((data) => {
       app.settings = data["response"];
       app.serviceList = Object.keys(data["response"]);
+
+      // console.log(data["response"]);
+
+      for (service in data["response"]) {
+        console.log(service);
+        for (resource in data["response"][service]) {
+          app.settingsFlat.push({
+            service: service,
+            resource: resource,
+            ttl: data["response"][service][resource]["ttl"],
+            enabled: data["response"][service][resource]["clean"],
+          });
+        }
+      }
     })
     .catch((error) => {
       iziToast.error({
         title: "Something went wrong",
         message: error,
         color: "#EC2B55",
+        titleColor: "white",
         messageColor: "white",
       });
     });

--- a/web/src/js/index.js
+++ b/web/src/js/index.js
@@ -173,13 +173,6 @@ function getExecutionLog(executionLogURL) {
       setTimeout(function () {
         $("#execution-log-table").DataTable({
           autoWidth: true,
-          columnDefs: [
-            {
-              className: "dt-body-nowrap",
-              targets: [1, 2, 3, 5],
-            },
-            { className: "dt-nowrap", targets: [1, 2, 3, 5] },
-          ],
           paging: false,
         });
         app.showExecutionLogLoadingGif = false;
@@ -309,10 +302,6 @@ function getWhitelist() {
           columnDefs: [
             { orderable: false, targets: [3, 4] },
             { className: "dt-center", targets: [4] },
-            {
-              className: "dt-body-nowrap",
-              targets: [0, 1, 2],
-            },
           ],
         });
       }, 10);

--- a/web/src/js/index.js
+++ b/web/src/js/index.js
@@ -197,7 +197,7 @@ function getExecutionLog(executionLogURL) {
         app.executionLogMode = "Destroy";
       }
 
-      for (log of data["response"]["body"]) {
+      for (const log of data["response"]["body"]) {
         // action taken
         app.executionLogActionStats[log["5"]] =
           ++app.executionLogActionStats[log["5"]] || 1;
@@ -264,7 +264,7 @@ function getServices() {
       app.serviceList = Object.keys(data["response"]);
 
       // convert settings to flat table
-      for (service in data["response"]) {
+      for (const service in data["response"]) {
         for (resource in data["response"][service]) {
           app.serviceSettingsFlat.push({
             service: service,

--- a/web/src/js/index.js
+++ b/web/src/js/index.js
@@ -347,6 +347,20 @@ function refreshWhitelist() {
     });
 }
 
+function openTab(evt, tabName) {
+  var i, x, tablinks;
+  x = document.getElementsByClassName("content-tab");
+  for (i = 0; i < x.length; i++) {
+    x[i].style.display = "none";
+  }
+  tablinks = document.getElementsByClassName("tab");
+  for (i = 0; i < x.length; i++) {
+    tablinks[i].className = tablinks[i].className.replace(" is-active", "");
+  }
+  document.getElementById(tabName).style.display = "block";
+  evt.currentTarget.className += " is-active";
+}
+
 // Get the API Gateway Base URL from manifest file
 fetch("serverless.manifest.json").then(function (response) {
   response.json().then(function (data) {

--- a/web/src/js/index.js
+++ b/web/src/js/index.js
@@ -19,6 +19,7 @@ var app = new Vue({
   data: {
     accountId: "",
     executionLogActionStats: {},
+    executionLogDataTables: "",
     executionLogKey: "",
     executionLogList: [],
     executionLogMode: "",
@@ -26,7 +27,6 @@ var app = new Vue({
     executionLogSearchTerm: "",
     executionLogServiceStats: {},
     executionLogTable: [],
-    executionLogDataTables: "",
     resourceIdPlaceholder: "",
     resourceList: [],
     selectedComment: "",
@@ -46,6 +46,8 @@ var app = new Vue({
     showWhitelistLoadingGif: false,
     showWhitelistPopup: false,
     whitelist: [],
+    whitelistDataTables: "",
+    whitelistSearchTerm: "",
   },
   methods: {
     // Whitelist
@@ -114,6 +116,9 @@ var app = new Vue({
       this.showWhitelistPopup = true;
       this.resourceIdPlaceholder = "";
     },
+    searchWhitelist: function () {
+      this.whitelistDataTables.search(this.whitelistSearchTerm).draw();
+    },
     // Execution Log
     closeExecutionLogPopup: function () {
       this.executionLogDataTables.destroy();
@@ -123,11 +128,11 @@ var app = new Vue({
       this.executionLogServiceStats = {};
       this.showExecutionLogPopup = false;
     },
-    executionLogSearch: function () {
-      this.executionLogDataTables.search(this.executionLogSearchTerm).draw();
-    },
     openExecutionLog: function (keyURL) {
       getExecutionLog(keyURL);
+    },
+    searchExecutionLog: function () {
+      this.executionLogDataTables.search(this.executionLogSearchTerm).draw();
     },
     // Help
     closeHelpPopup: function () {
@@ -228,6 +233,7 @@ function getExecutionLogList() {
       });
       setTimeout(function () {
         $("#execution-log-list-table").DataTable({
+          dom: "rtp",
           columnDefs: [
             { orderable: false, targets: [2] },
             { className: "dt-center", targets: [2] },
@@ -305,7 +311,8 @@ function getWhitelist() {
       });
 
       setTimeout(function () {
-        $("#whitelist").DataTable({
+        app.whitelistDataTables = $("#whitelist").DataTable({
+          dom: "rtp",
           columnDefs: [
             { orderable: false, targets: [3, 4] },
             { className: "dt-center", targets: [4] },


### PR DESCRIPTION
## Description

- Added AWS Account ID to the navigation bar and webpage title.
- Added default sorting (by log name in descending order) within the execution log list table. This ensures the latest execution logs are always first.
- Added EC2 Image (AMI) cleanup.
- Added execution log statistics to the execution log popup. Statistics include a breakdown of counts by service, action taken, and region.
- Added help section to the website introducing new users to Auto Cleanup as well as exposing AWS service settings from the Settings table.
- Fixed an issue where Auto Cleanup was attempting to delete automated Redshift and RDS snapshots. Only manual snapshots can be deleted.
- Fixed an issue where EC2 Snapshots were incorrectly marked as "in use" and not deleted.
- Improved CloudFormation Stacks deletion. Stack deletions are now processed in parallel for a given region.
- Improved execution logging with finer-grained information.
- Improved S3 Bucket deletion by using Boto3 `resource` instead of `client`.
- Modified AWS Auto Cleanup App memory allocation from 256 MB to 512 MB.
- Modified AWS Auto Cleanup App timeout from 5 minutes to 15 minutes.