### PR TITLE
EC2 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # AWS Auto Cleanup Changelog
 
+## 1.5.1
+
+- Fixed broken EC2 Instance cleanup. The existing filter on the `describe-instances` API request was invalid and filtering out all EC2 instances.
+- Modified the TTL expiration set when adding new whitelist entries. New entries will now be whitelisted for double the TTL duration. In other words, when creating a new EC2 instance, it will automatically be whitelisted for 14 days instead of the default 7. The previous functionality didn't make too much sense as the whitelisting duration was the same as the default non-whitelisted behaviour.
+
 ## 1.5.0
 
 - Added API authentication (thanks to @miki79)

--- a/api/src/whitelist/create.py
+++ b/api/src/whitelist/create.py
@@ -91,7 +91,7 @@ def lambda_handler(event, context):
     if parameters.get("permanent", False):
         expiration = 4102444800
     else:
-        expiration = int(time.time()) + (resource_ttl * 86400)
+        expiration = int(time.time()) + ((resource_ttl * 2) * 86400)
 
     try:
         boto3.client("dynamodb").put_item(

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-cleanup-app",
   "description": "Auto Cleanup App",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "devDependencies": {
     "serverless-pseudo-parameters": "^2.5.0",

--- a/app/serverless.yml
+++ b/app/serverless.yml
@@ -385,18 +385,12 @@ resources:
     ExecutionLogBucketName:
       Value:
         Ref: ExecutionLogBucket
-      Export:
-        Name: ExecutionLogBucketName
     SettingsTableName:
       Value:
         Ref: SettingsTable
-      Export:
-        Name: SettingsTableName
     WhitelistTableName:
       Value:
         Ref: WhitelistTable
-      Export:
-        Name: WhitelistTableName
 
 plugins:
   - serverless-pseudo-parameters

--- a/app/src/ec2_cleanup.py
+++ b/app/src/ec2_cleanup.py
@@ -219,16 +219,7 @@ class EC2Cleanup:
             try:
                 paginator = self.client_ec2.get_paginator("describe_instances")
                 reservations = (
-                    paginator.paginate(
-                        Filters=[
-                            {
-                                "Name": "state-reason-message",
-                                "Values": ["running", "stopped"],
-                            },
-                        ]
-                    )
-                    .build_full_result()
-                    .get("Reservations")
+                    paginator.paginate().build_full_result().get("Reservations")
                 )
             except:
                 self.logging.error("Could not list all EC2 Instances.")


### PR DESCRIPTION
## Description

- Fixed broken EC2 Instance cleanup. The existing filter on the `describe-instances` API request was invalid and filtering out all EC2 instances.
- Modified the TTL expiration set when adding new whitelist entries. New entries will now be whitelisted for double the TTL duration. In other words, when creating a new EC2 instance, it will automatically be whitelisted for 14 days instead of the default 7. The previous functionality didn't make too much sense as the whitelisting duration was the same as the default non-whitelisted behaviour.

### Related issue(s) (if applicable)

- Fixes #81 

## Checklist

### Generic

- [X] Have you followed the guidelines in our [Contributing](https://github.com/servian/aws-auto-cleanup/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/servian/aws-auto-cleanup/pulls) for the same update/change?

### Development

- [X] Have you added comments to all relevant changes within the code?
- [X] Have you lint your code locally prior to submission?
- [X] Have you formatted (Python Black and Prettier) your code locally prior to submission?

### Testing

- [ ] Have you created new tests for your submission?
- [ ] Does your submission pass all tests?
- [ ] Does your submission improve or at the very least kept code coverage at the same percentage?

### Documentation

- [X] Have you added or changed any and all applicable documentation?
