### PR TITLE
Managed policy fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # AWS Auto Cleanup Changelog
 
+## 1.5.4
+
+- Fixed issue with CloudFormation Stack whitelisted Managed Policies. Whilst the Managed Policies were whitelisted, their resource was `ManagedPolicy` and not `Policy` which is checked for whitelisting.
+
 ## 1.5.3
 
 - Added missing execution log action for whitelisted EC2 Security Groups.

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-cleanup-app",
   "description": "Auto Cleanup App",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "private": true,
   "devDependencies": {
     "serverless-python-requirements": "^5.1.0"

--- a/app/src/cloudformation_cleanup.py
+++ b/app/src/cloudformation_cleanup.py
@@ -17,6 +17,8 @@ class CloudFormationCleanup:
         self._client_cloudformation = None
         self.is_dry_run = Helper.get_setting(self.settings, "general.dry_run", True)
 
+        self.resource_translations = {"ManagedPolicy": "Policy"}
+
     @property
     def client_cloudformation(self):
         if not self._client_cloudformation:
@@ -252,6 +254,9 @@ class CloudFormationCleanup:
                         # resource ID. Strip the ARN to just the resource ID.
                         if "/" in resource_child_id:
                             resource_child_id = resource_child_id.split("/")[1]
+
+                        if resource in self.resource_translations:
+                            resource = self.resource_translations[resource]
 
                         self.whitelist[service.lower()][resource.lower()].add(
                             resource_child_id

--- a/app/src/cloudformation_cleanup.py
+++ b/app/src/cloudformation_cleanup.py
@@ -248,6 +248,11 @@ class CloudFormationCleanup:
                             "does not conform to the standard 'service-provider::service-name::data-type-name' and cannot be whitelisted."
                         )
                     else:
+                        # Some resources are coming through as full ARNs instead of just
+                        # resource ID. Strip the ARN to just the resource ID.
+                        if "/" in resource_child_id:
+                            resource_child_id = resource_child_id.split("/")[1]
+
                         self.whitelist[service.lower()][resource.lower()].add(
                             resource_child_id
                         )


### PR DESCRIPTION
## Description

- Fixed issue with CloudFormation Stack whitelisted Managed Policies. Whilst the Managed Policies were whitelisted, their resource was `ManagedPolicy` and not `Policy` which is checked for whitelisting.

### Related issue(s) (if applicable)

- Fixes #97