### PR TITLE
Missing PhysicalResourceId throws error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # AWS Auto Cleanup Changelog
 
+## 1.5.5
+
+- Fixed issue that was introduced in 1.5.4. Deleted Cloudformation Stack Resources no longer have a `PhysicalResourceId` property. This caused an error when attempting to whitelist the Stack Resources.
+
 ## 1.5.4
 
 - Fixed issue with CloudFormation Stack whitelisted Managed Policies. Whilst the Managed Policies were whitelisted, their resource was `ManagedPolicy` and not `Policy` which is checked for whitelisting.

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-cleanup-app",
   "description": "Auto Cleanup App",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "private": true,
   "devDependencies": {
     "serverless-python-requirements": "^5.1.0"


### PR DESCRIPTION
## Description

- Fixed issue that was introduced in 1.5.4. Deleted Cloudformation Stack Resources no longer have a `PhysicalResourceId` property. This caused an error when attempting to whitelist the Stack Resources.

### Related issue(s) (if applicable)

- Fixes #100