### PR TITLE
Added ec2:DeleteVpcEndpoints action needed to delete serverless Kafka clusters

### DIFF
--- a/app/serverless.yml
+++ b/app/serverless.yml
@@ -191,6 +191,7 @@ provider:
           Action:
             - kafka:DeleteCluster
             - kafka:ListClustersV2
+            - ec2:DeleteVpcEndpoints
           Resource: "*"
         - Effect: Allow
           Action:


### PR DESCRIPTION
## Description

Access to `ec2:DeleteVpcEndpoints` is needed to be able to delete serverless kafka clusters. The following error came up when the cleanup role did not have access to the action:

```
There is an issue with your clusters.
Code: InvalidInput.InsufficientPermissionException
Message: Amazon MSK could not create or delete your cluster because you don't have the necessary permissions required for the operation.
```

### Related issue(s) (if applicable)

- Fixes #113

## Checklist

### Generic

- [X] Have you followed the guidelines in our [Contributing](https://github.com/servian/aws-auto-cleanup/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/servian/aws-auto-cleanup/pulls) for the same update/change?

### Development

- [X] Have you added comments to all relevant changes within the code?
- [N] Have you lint your code locally prior to submission?
- [N] Have you formatted (Python Black and Prettier) your code locally prior to submission?

### Testing

- [X] Have you created new tests for your submission?
- [X] Does your submission pass all tests?
- [X] Does your submission improve or at the very least kept code coverage at the same percentage?

### Documentation

- [X] Have you added or changed any and all applicable documentation?
