### PR TITLE
Responsive allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# AWS Auto Cleanup Changelog
+# Changelog
+
+## UNRELEASED
+
+- Updated Allowlist display hiding Owner and Comment columns behind a expand button. This will allow for a more clean display of resources and their ID's.
 
 ## 2.3.0
 

--- a/web/src/css/style.css
+++ b/web/src/css/style.css
@@ -14,6 +14,10 @@ tr .button {
   box-sizing: border-box !important;
 }
 
+::before {
+  box-shadow: none !important;
+}
+
 td {
   vertical-align: middle !important;
 }

--- a/web/src/css/style.css
+++ b/web/src/css/style.css
@@ -10,9 +10,7 @@ table.table {
   width: 100%;
 }
 
-tr .button,
-::after,
-::before {
+tr .button {
   box-sizing: border-box !important;
 }
 

--- a/web/src/css/style.css
+++ b/web/src/css/style.css
@@ -22,7 +22,17 @@ td {
   vertical-align: middle !important;
 }
 
-td.dt-body-nowrap { white-space: nowrap; }
+td.dt-body-nowrap {
+  white-space: nowrap;
+}
+
+td.dtr-control:before {
+  background-color: #ffe08a !important;
+  color: black !important;
+  font-family: inherit !important;
+  line-height: 0.89em !important;
+  border-radius: 4px !important;
+}
 
 .execution-log-modal {
   width: calc(100vw - 40px) !important;

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -68,7 +68,12 @@
     />
     <link
       rel="stylesheet"
-      href="https://cdn.datatables.net/1.10.22/css/dataTables.bulma.min.css"
+      href="https://cdn.datatables.net/1.12.1/css/dataTables.bulma.min.css"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.datatables.net/responsive/2.3.0/css/responsive.bulma.min.css"
       crossorigin="anonymous"
     />
     <link
@@ -165,36 +170,40 @@
             </div>
           </div>
         </nav>
-        <table class="table" id="allowlist" style="table-layout: fixed">
+        <table
+          id="allowlist"
+          class="table is-striped responsive nowrap"
+          style="width: 100%"
+        >
           <thead>
             <tr>
               <th>Service</th>
               <th>Resource</th>
               <th>ID</th>
               <th>Expiration</th>
-              <th>Owner</th>
-              <th>Comment</th>
+              <th class="none">Owner</th>
+              <th class="none">Comment</th>
               <th>Type</th>
               <th style="text-align: center">Actions</th>
             </tr>
           </thead>
           <tbody>
             <tr v-for="item in allowlist" :key="item.row_id">
-              <td style="white-space: nowrap">{{ item.service }}</td>
-              <td style="white-space: nowrap">{{ item.resource }}</td>
-              <td style="word-break: break-all">{{ item.id }}</td>
+              <td>{{ item.service }}</td>
+              <td>{{ item.resource }}</td>
+              <td>{{ item.id }}</td>
               <td>
                 <span v-if="item.expiration < '4102444800'"
                   >{{ item.expiration_readable }}</span
                 >
               </td>
-              <td style="white-space: nowrap">{{ item.owner }}</td>
-              <td style="word-break: break-all">{{ item.comment }}</td>
+              <td>{{ item.owner }}</td>
+              <td>{{ item.comment }}</td>
               <td>
                 <span v-if="item.expiration < '4102444800'">Temporary</span>
                 <span v-if="item.expiration >= '4102444800'">Permanent</span>
               </td>
-              <td style="white-space: nowrap; text-align: center">
+              <td style="text-align: center">
                 <button
                   class="button is-warning"
                   v-if="item.expiration < '4102444800'"
@@ -233,7 +242,7 @@
           </div>
         </nav>
 
-        <table class="table" id="execution-log-list-table">
+        <table id="execution-log-list-table" class="table">
           <thead>
             <th>Log</th>
             <th>Date</th>
@@ -322,7 +331,7 @@
               <div class="content">
                 <div class="container is-fluid p-0">
                   <div id="logs" class="content-tab">
-                    <table class="table" id="execution-log-table">
+                    <table id="execution-log-table" class="table">
                       <thead>
                         <tr>
                           <th>Timestamp</th>
@@ -342,7 +351,7 @@
                   >
                     <div class="columns">
                       <div class="column">
-                        <table class="table" id="execution-log-table">
+                        <table id="execution-log-table" class="table">
                           <thead>
                             <tr>
                               <th>Resource</th>
@@ -353,14 +362,14 @@
                             <tr
                               v-for="key in Object.keys(executionLogServiceStats).sort()"
                             >
-                              <td style="white-space: nowrap">{{key}}</td>
+                              <td>{{key}}</td>
                               <td>{{executionLogServiceStats[key]}}</td>
                             </tr>
                           </tbody>
                         </table>
                       </div>
                       <div class="column">
-                        <table class="table" id="execution-log-table">
+                        <table id="execution-log-table" class="table">
                           <thead>
                             <tr>
                               <th>Action</th>
@@ -371,14 +380,14 @@
                             <tr
                               v-for="key in Object.keys(executionLogActionStats).sort()"
                             >
-                              <td style="white-space: nowrap">{{key}}</td>
+                              <td>{{key}}</td>
                               <td>{{executionLogActionStats[key]}}</td>
                             </tr>
                           </tbody>
                         </table>
                       </div>
                       <div class="column">
-                        <table class="table" id="execution-log-table">
+                        <table id="execution-log-table" class="table">
                           <thead>
                             <tr>
                               <th>Region</th>
@@ -389,7 +398,7 @@
                             <tr
                               v-for="key in Object.keys(executionLogRegionStats).sort()"
                             >
-                              <td style="white-space: nowrap">{{key}}</td>
+                              <td>{{key}}</td>
                               <td>{{executionLogRegionStats[key]}}</td>
                             </tr>
                           </tbody>
@@ -744,28 +753,32 @@
 
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.7.4/vue.min.js"
-      integrity="sha512-ReiTH8bLMRWfRdFMuHPWq8Wk+7a2JQhfLWx2YgnjJ35TVU9MkQKioiHt5TfHzbHXIXM58TkFwukQ5+DlyJkg3A=="
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     ></script>
     <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"
-      integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ=="
+      src="https://code.jquery.com/jquery-3.5.1.js"
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     ></script>
     <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.21/js/jquery.dataTables.min.js"
-      integrity="sha512-BkpSL20WETFylMrcirBahHfSnY++H2O1W+UnEEO4yNIl+jI2+zowyoGJpbtk6bx97fBXf++WJHSSK2MV4ghPcg=="
+      src="https://cdn.datatables.net/1.12.1/js/jquery.dataTables.min.js"
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/datatables.net-rowgroup/1.1.2/dataTables.rowGroup.min.js"
-      integrity="sha512-ock7SbKoWBDD9MiniUi9p7WlkqpfRL1sM3CsWX7LxORuyLPRyzR484V8SVrTIWqhxtCVNnfcbOo+cRlHIhiwbg=="
+      src="https://cdn.datatables.net/1.12.1/js/dataTables.bulma.min.js"
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://cdn.datatables.net/1.10.22/js/dataTables.bulma.min.js"
+      src="https://cdn.datatables.net/rowgroup/1.2.0/js/dataTables.rowGroup.min.js"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.datatables.net/responsive/2.3.0/js/dataTables.responsive.min.js"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.datatables.net/responsive/2.3.0/js/responsive.bulma.min.js"
       crossorigin="anonymous"
     ></script>
     <script

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -193,7 +193,9 @@
               <td>{{ item.resource }}</td>
               <td>{{ item.id }}</td>
               <td>
-                <span v-if="item.expiration < '4102444800'"
+                <span
+                  v-if="item.expiration < '4102444800'"
+                  :title="item.expiration_tooltip"
                   >{{ item.expiration_readable }}</span
                 >
               </td>
@@ -537,7 +539,22 @@
                 </div>
 
                 <div class="field">
-                  <label class="label">ID</label>
+                  <label class="label"
+                    >ID
+                    <span
+                      style="
+                        font-size: x-small;
+                        font-weight: normal;
+                        vertical-align: middle;
+                      "
+                      >(supports
+                      <a
+                        href="https://github.com/servian/aws-auto-cleanup/tree/main/app#wildcard"
+                        target="_blank"
+                        >wildcards</a
+                      >)</span
+                    ></label
+                  >
                   <div class="control has-icons-left">
                     <input
                       :placeholder="[[ resourceIdPlaceholder ]]"

--- a/web/src/js/index.js
+++ b/web/src/js/index.js
@@ -423,7 +423,7 @@ function getAllowlist() {
             },
             { responsivePriority: 1, targets: 7 },
           ],
-          // order: [[6, "desc"]],
+          order: [[6, "desc"]],
           pageLength: 20,
           rowGroup: {
             dataSrc: 6,

--- a/web/src/js/index.js
+++ b/web/src/js/index.js
@@ -403,7 +403,9 @@ function getAllowlist() {
         item["resource"] = parsedResourceId[1];
         item["id"] = parsedResourceId[2];
 
-        item["expiration_readable"] = readableDate.format(
+        item["expiration_readable"] = readableDate.format("DD MMM YYYY");
+
+        item["expiration_tooltip"] = readableDate.format(
           "ddd MMM DD HH:mm:ss YYYY"
         );
 

--- a/web/src/js/index.js
+++ b/web/src/js/index.js
@@ -412,6 +412,7 @@ function getAllowlist() {
 
       setTimeout(function () {
         app.allowlistDataTables = $("#allowlist").DataTable({
+          dom: "rtp",
           columnDefs: [
             { className: "dt-center", targets: [5] },
             { orderable: false, targets: [0, 1, 2, 3, 4, 5, 6, 7] },
@@ -420,9 +421,9 @@ function getAllowlist() {
               visible: false,
               searchable: false,
             },
+            { responsivePriority: 1, targets: 7 },
           ],
-          dom: "rtp",
-          order: [[6, "desc"]],
+          // order: [[6, "desc"]],
           pageLength: 20,
           rowGroup: {
             dataSrc: 6,


### PR DESCRIPTION
## Description

- Updated Allowlist display hiding Owner and Comment columns behind a expand button. This will allow for a more clean display of resources and their ID's.

### Related issue(s) (if applicable)

N/A

## Checklist

### Generic

- [X] Have you followed the guidelines in our [Contributing](https://github.com/servian/aws-auto-cleanup/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/servian/aws-auto-cleanup/pulls) for the same update/change?

### Development

- [X] Have you added comments to all relevant changes within the code?
- [X] Have you lint your code locally prior to submission?
- [X] Have you formatted (Python Black and Prettier) your code locally prior to submission?