### PR TITLE
Better EC2 launch time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - Updated Allowlist display hiding Owner and Comment columns behind a expand button. This will allow for a more clean display of resources and their ID's.
+- Changed the date used to calculate the age of an EC2 Instance. Instead of using the EC2 Instance `LaunchTime` which resets everytime an EC2 Instance is stopped and started, the EC2 Instance's ENI `AttachTime` is used instead. [#129](https://github.com/servian/aws-auto-cleanup/issues/129).
 
 ## 2.3.0
 

--- a/app/src/ec2_cleanup.py
+++ b/app/src/ec2_cleanup.py
@@ -223,7 +223,7 @@ class EC2Cleanup:
             for reservation in reservations:
                 for resource in reservation.get("Instances"):
                     resource_id = resource.get("InstanceId")
-                    resource_date = resource.get("LaunchTime")
+                    resource_date = self.__get_ec2_launch_time(resource)
                     resource_state = resource.get("State").get("Name")
                     resource_age = Helper.get_day_delta(resource_date).days
                     resource_action = None
@@ -672,3 +672,10 @@ class EC2Cleanup:
         else:
             self.logging.info("Skipping cleanup of EC2 Volumes.")
             return True
+
+    def __get_ec2_launch_time(self, resource):
+        for network_interface in resource.get("NetworkInterfaces"):
+            if network_interface.get("Attachment").get("DeviceIndex") == 0:
+                return network_interface.get("Attachment").get("AttachTime")
+
+        return resource.get("LaunchTime")


### PR DESCRIPTION
## Description

- Changed the date used to calculate the age of an EC2 Instance. Instead of using the EC2 Instance `LaunchTime` which resets everytime an EC2 Instance is stopped and started, the EC2 Instance's ENI `AttachTime` is used instead. [#129](https://github.com/servian/aws-auto-cleanup/issues/129).

### Related issue(s) (if applicable)

- Fixes #129