### PR TITLE
Better homepage design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - Updated Allowlist display hiding Owner and Comment columns behind a expand button. This will allow for a more clean display of resources and their ID's.
+- Changed the date used to calculate the age of an EC2 Instance. Instead of using the EC2 Instance `LaunchTime` which resets everytime an EC2 Instance is stopped and started, the EC2 Instance's ENI `AttachTime` is used instead. [#129](https://github.com/servian/aws-auto-cleanup/issues/129).
 
 ## 2.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## UNRELEASED
+## 2.4.0
 
 - Updated Allowlist display hiding Owner and Comment columns behind a expand button. This will allow for a more clean display of resources and their ID's.
 - Changed the date used to calculate the age of an EC2 Instance. Instead of using the EC2 Instance `LaunchTime` which resets everytime an EC2 Instance is stopped and started, the EC2 Instance's ENI `AttachTime` is used instead. [#129](https://github.com/servian/aws-auto-cleanup/issues/129).
+- Updated homescreen design with an encapsulated allowlist and execution log, including a number of QoL changes.
 
 ## 2.3.0
 

--- a/app/src/ec2_cleanup.py
+++ b/app/src/ec2_cleanup.py
@@ -223,7 +223,7 @@ class EC2Cleanup:
             for reservation in reservations:
                 for resource in reservation.get("Instances"):
                     resource_id = resource.get("InstanceId")
-                    resource_date = resource.get("LaunchTime")
+                    resource_date = self.__get_ec2_launch_time(resource)
                     resource_state = resource.get("State").get("Name")
                     resource_age = Helper.get_day_delta(resource_date).days
                     resource_action = None
@@ -672,3 +672,10 @@ class EC2Cleanup:
         else:
             self.logging.info("Skipping cleanup of EC2 Volumes.")
             return True
+
+    def __get_ec2_launch_time(self, resource):
+        for network_interface in resource.get("NetworkInterfaces"):
+            if network_interface.get("Attachment").get("DeviceIndex") == 0:
+                return network_interface.get("Attachment").get("AttachTime")
+
+        return resource.get("LaunchTime")

--- a/web/src/css/style.css
+++ b/web/src/css/style.css
@@ -33,6 +33,7 @@ td.dtr-control:before {
   font-family: inherit !important;
   line-height: 0.89em !important;
   border-radius: 4px !important;
+  border-color: inherit;
 }
 
 .execution-log-modal {

--- a/web/src/css/style.css
+++ b/web/src/css/style.css
@@ -8,6 +8,7 @@ html {
 
 table.table {
   width: 100%;
+  background-color: inherit !important;
 }
 
 tr .button {
@@ -60,4 +61,12 @@ tr.dtrg-group {
 
 .remove-overflow {
   overflow: hidden;
+}
+
+a {
+  text-decoration: none !important;
+}
+
+.message-header {
+  font-weight: normal !important;
 }

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="overflow: hidden;">
   <head>
     <!-- Primary Meta Tags -->
     <title>AWS Auto Cleanup</title>
@@ -165,6 +165,14 @@
               <p class="control">
                 <button
                   class="button is-white"
+                  v-on:click="expandAllowlist()"
+                >
+                  <span class="icon"> <i id="allowlist-expand-icon" class="fas fa-up-right-and-down-left-from-center"></i> </span>
+                </button>
+              </p>
+              <p class="control">
+                <button
+                  class="button is-warning"
                   v-on:click="openAllowlistInsertPopup()"
                 >
                   <span class="icon"> <i class="fas fa-plus"></i> </span>
@@ -172,7 +180,7 @@
               </p>
             </div>
           </div>
-          <div class="message-body" style="max-height: calc(100vh - 64vh); overflow-y:auto">
+          <div class="message-body" id="allowlist-message-body" style="max-height: calc(36vh); overflow-y:auto">
             <table
               id="allowlist"
               class="table is-striped responsive nowrap"
@@ -249,9 +257,17 @@
             <p class="modal-card-title" style="color: white;">Execution Log</p>
             <div class="field is-grouped">
               <p class="control" id="execution-log-list-table-paginate"></p>
+              <p class="control">
+                <button
+                  class="button is-white"
+                  v-on:click="expandExecutionLog()"
+                >
+                  <span class="icon"> <i id="execution-log-expand-icon" class="fas fa-up-right-and-down-left-from-center"></i> </span>
+                </button>
+              </p>
             </div>
           </div>
-          <div class="message-body" style="max-height: calc(100vh - 64vh); overflow-y:auto">
+          <div class="message-body" id="execution-log-message-body" style="max-height: calc(36vh); overflow-y:auto">
             <table id="execution-log-list-table" class="table">
               <thead>
                 <th>Log</th>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" style="overflow: hidden;">
+<html lang="en">
   <head>
     <!-- Primary Meta Tags -->
     <title>AWS Auto Cleanup</title>
@@ -143,7 +143,7 @@
 
       <!-- Body -->
       <div class="container body-container">
-        <article class="message">
+        <article class="message" id="allowlist-message">
           <div class="message-header">
             <p class="modal-card-title" style="color: white;">Allowlist</p>
             <div class="field is-grouped">
@@ -180,7 +180,7 @@
               </p>
             </div>
           </div>
-          <div class="message-body" id="allowlist-message-body" style="max-height: calc(36vh); overflow-y:auto">
+          <div class="message-body" id="allowlist-message-body" style="max-height: calc(100vh / 3); overflow-y:auto">
             <table
               id="allowlist"
               class="table is-striped responsive nowrap"
@@ -252,7 +252,7 @@
         <br />
 
         <!-- Execution Log -->
-        <article class="message">
+        <article class="message" id="execution-log-message">
           <div class="message-header" style="height: 64px;">
             <p class="modal-card-title" style="color: white;">Execution Log</p>
             <div class="field is-grouped">
@@ -267,7 +267,7 @@
               </p>
             </div>
           </div>
-          <div class="message-body" id="execution-log-message-body" style="max-height: calc(36vh); overflow-y:auto">
+          <div class="message-body" id="execution-log-message-body" style="max-height: calc(100vh / 3); overflow-y:auto">
             <table id="execution-log-list-table" class="table">
               <thead>
                 <th>Log</th>

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -143,91 +143,97 @@
 
       <!-- Body -->
       <div class="container body-container">
-        <nav class="level">
-          <div class="level-left">
-            <h3 class="title is-3 mb-0 mr-2">Allowlist</h3>
-            <!-- <h2 class="title">Allowlist</h2> -->
-            <button
-              class="button is-warning"
-              v-on:click="openAllowlistInsertPopup()"
-            >
-              <span class="icon"> <i class="fas fa-plus"></i> </span>
-              <span>New Entry</span>
-            </button>
-          </div>
-          <div class="level-right">
-            <div class="control has-icons-left is-right">
-              <input
-                class="input"
-                placeholder="Search"
-                type="text"
-                v-model="allowlistSearchTerm"
-                v-on:keyup="searchAllowlist()"
-              />
-              <span class="icon is-left">
-                <i class="fas fa-search"></i>
-              </span>
+        <article class="message">
+          <div class="message-header">
+            <p class="modal-card-title" style="color: white;">Allowlist</p>
+            <div class="field is-grouped">
+              <p class="control is-expanded">
+                <div class="control has-icons-left is-right">
+                  <input
+                    class="input"
+                    placeholder="Search"
+                    type="text"
+                    v-model="allowlistSearchTerm"
+                    v-on:keyup="searchAllowlist()"
+                  />
+                  <span class="icon is-left">
+                    <i class="fas fa-search"></i>
+                  </span>
+                </div>
+              </p>
+              <p class="control" id="allowlist-paginate"></p>
+              <p class="control">
+                <button
+                  class="button is-white"
+                  v-on:click="openAllowlistInsertPopup()"
+                >
+                  <span class="icon"> <i class="fas fa-plus"></i> </span>
+                </button>
+              </p>
             </div>
           </div>
-        </nav>
-        <table
-          id="allowlist"
-          class="table is-striped responsive nowrap"
-          style="width: 100%"
-        >
-          <thead>
-            <tr>
-              <th>Service</th>
-              <th>Resource</th>
-              <th>ID</th>
-              <th>Expiration</th>
-              <th class="none">Owner</th>
-              <th class="none">Comment</th>
-              <th>Type</th>
-              <th style="text-align: center">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="item in allowlist" :key="item.row_id">
-              <td>{{ item.service }}</td>
-              <td>{{ item.resource }}</td>
-              <td>{{ item.id }}</td>
-              <td>
-                <span
-                  v-if="item.expiration < '4102444800'"
-                  :title="item.expiration_tooltip"
-                  >{{ item.expiration_readable }}</span
-                >
-              </td>
-              <td>{{ item.owner }}</td>
-              <td>{{ item.comment }}</td>
-              <td>
-                <span v-if="item.expiration < '4102444800'">Temporary</span>
-                <span v-if="item.expiration >= '4102444800'">Permanent</span>
-              </td>
-              <td style="text-align: center">
-                <button
-                  class="button is-warning"
-                  v-if="item.expiration < '4102444800'"
-                  v-on:click="extendAllowlistEntry( item.row_id )"
-                >
-                  <span class="icon">
-                    <i class="far fa-calendar-plus"></i>
-                  </span>
-                </button>
-                <button
-                  class="button is-danger"
-                  v-if="item.expiration < '4102444800'"
-                  v-on:click="openAllowlistDeletePopup( item.resource_id )"
-                >
-                  <span class="icon">
-                    <i class="far fa-trash-alt"></i>
-                  </span>
-                </button>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+          <div class="message-body" style="max-height: calc(100vh - 64vh); overflow-y:auto">
+            <table
+              id="allowlist"
+              class="table is-striped responsive nowrap"
+              style="width: 100%"
+            >
+              <thead>
+                <tr>
+                  <th>Service</th>
+                  <th>Resource</th>
+                  <th>ID</th>
+                  <th>Expiration</th>
+                  <th class="none">Owner</th>
+                  <th class="none">Comment</th>
+                  <th>Type</th>
+                  <th style="text-align: center">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="item in allowlist" :key="item.row_id">
+                  <td>{{ item.service }}</td>
+                  <td>{{ item.resource }}</td>
+                  <td>{{ item.id }}</td>
+                  <td>
+                    <span
+                      v-if="item.expiration < '4102444800'"
+                      :title="item.expiration_tooltip"
+                      >{{ item.expiration_readable }}</span
+                    >
+                  </td>
+                  <td>{{ item.owner }}</td>
+                  <td>{{ item.comment }}</td>
+                  <td>
+                    <span v-if="item.expiration < '4102444800'">Temporary</span>
+                    <span v-if="item.expiration >= '4102444800'">Permanent</span>
+                  </td>
+                  <td style="text-align: center">
+                    <button
+                      class="button is-warning"
+                      v-if="item.expiration < '4102444800'"
+                      v-on:click="extendAllowlistEntry( item.row_id )"
+                    >
+                      <span class="icon">
+                        <i class="far fa-calendar-plus"></i>
+                      </span>
+                    </button>
+                    <button
+                      class="button is-danger"
+                      v-if="item.expiration < '4102444800'"
+                      v-on:click="openAllowlistDeletePopup( item.resource_id )"
+                    >
+                      <span class="icon">
+                        <i class="far fa-trash-alt"></i>
+                      </span>
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </article>
+        
         <!-- Refreshing Animation -->
         <div
           class="container has-text-centered"
@@ -238,36 +244,42 @@
         <br />
 
         <!-- Execution Log -->
-        <nav class="level">
-          <div class="level-left">
-            <h3 class="title is-3 mt-2 mb-0 mr-2">Execution Logs</h3>
+        <article class="message">
+          <div class="message-header" style="height: 64px;">
+            <p class="modal-card-title" style="color: white;">Execution Log</p>
+            <div class="field is-grouped">
+              <p class="control" id="execution-log-list-table-paginate"></p>
+            </div>
           </div>
-        </nav>
+          <div class="message-body" style="max-height: calc(100vh - 64vh); overflow-y:auto">
+            <table id="execution-log-list-table" class="table">
+              <thead>
+                <th>Log</th>
+                <th>Date</th>
+                <th>View</th>
+              </thead>
+              <tbody>
+                <tr v-for="item in executionLogList" :value="item" :key="item.key">
+                  <td>{{ item.key }}</td>
+                  <td>{{ item.local_date }}</td>
+                  <td>
+                    <button
+                      v-on:click="openExecutionLog( item.key_escape )"
+                      target="_blank"
+                      class="button"
+                    >
+                      <span class="icon">
+                        <i class="fas fa-arrow-up-right-from-square"></i>
+                      </span>
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </article>
 
-        <table id="execution-log-list-table" class="table">
-          <thead>
-            <th>Log</th>
-            <th>Date</th>
-            <th>View</th>
-          </thead>
-          <tbody>
-            <tr v-for="item in executionLogList" :value="item" :key="item.key">
-              <td>{{ item.key }}</td>
-              <td>{{ item.local_date }}</td>
-              <td>
-                <button
-                  v-on:click="openExecutionLog( item.key_escape )"
-                  target="_blank"
-                  class="button"
-                >
-                  <span class="icon">
-                    <i class="fas fa-arrow-up-right-from-square"></i>
-                  </span>
-                </button>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        
         <!-- Refreshing Animation -->
         <div
           class="container has-text-centered"

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -147,6 +147,22 @@
           <div class="message-header">
             <p class="modal-card-title" style="color: white;">Allowlist</p>
             <div class="field is-grouped">
+              <div class="field has-addons" style="margin-bottom: 0% !important;">
+                <p class="control">
+                  <button
+                    class="button is-link"
+                    id="show-temporary-allowlist-button"
+                    v-on:click="showTemporaryAllowlist()"
+                  >Temporary</button>
+                </p>
+                <p class="control">
+                  <button
+                    class="button is-white"
+                    id="show-permanent-allowlist-button"
+                    v-on:click="showPermanentAllowlist()"
+                  >Permanent</button>
+                </p>
+              </div>
               <p class="control is-expanded">
                 <div class="control has-icons-left is-right">
                   <input
@@ -180,10 +196,10 @@
               </p>
             </div>
           </div>
-          <div class="message-body" id="allowlist-message-body" style="max-height: calc(100vh / 3); overflow-y:auto">
+          <div class="message-body" id="allowlist-message-body" style="max-height: calc(36vh); overflow-y:auto">
             <table
               id="allowlist"
-              class="table is-striped responsive nowrap"
+              class="table responsive nowrap"
               style="width: 100%"
             >
               <thead>
@@ -267,7 +283,7 @@
               </p>
             </div>
           </div>
-          <div class="message-body" id="execution-log-message-body" style="max-height: calc(100vh / 3); overflow-y:auto">
+          <div class="message-body" id="execution-log-message-body" style="max-height: calc(36vh); overflow-y:auto">
             <table id="execution-log-list-table" class="table">
               <thead>
                 <th>Log</th>

--- a/web/src/js/index.js
+++ b/web/src/js/index.js
@@ -115,13 +115,17 @@ var app = new Vue({
         // $("html").removeClass("remove-overflow");
         this.allowlistExpanded = false;
       } else {
-        $("#allowlist-message-body").css({ "max-height": "calc(83vh)" });
-        $("#allowlist-message-body").css({ "min-height": "calc(83vh)" });
+        $("#allowlist-message-body").css({ "max-height": "calc(88vh)" });
+        $("#allowlist-message-body").css({ "min-height": "calc(88vh)" });
         $("#allowlist-expand-icon").attr(
           "class",
           "fas fa-down-left-and-up-right-to-center"
         );
         // $("html").addClass("remove-overflow");
+        $("html, body").animate(
+          { scrollTop: $("#allowlist-message").offset().top - 20 },
+          500
+        );
         this.allowlistExpanded = true;
       }
     },
@@ -142,7 +146,12 @@ var app = new Vue({
           "class",
           "fas fa-down-left-and-up-right-to-center"
         );
-        $("html, body").animate({ scrollTop: $(document).height() }, 1000);
+        // $("html, body").animate({ scrollTop: $(document).height() }, 1000);
+        $("html, body").animate(
+          { scrollTop: $("#execution-log-message").offset().top - 20 },
+          500
+        );
+
         // $("html").addClass("remove-overflow");
         this.executionLogExpanded = true;
       }

--- a/web/src/js/index.js
+++ b/web/src/js/index.js
@@ -496,6 +496,7 @@ function getAllowlist() {
           pageLength: 500,
         });
         $("#allowlist-paginate").html($("#allowlist_paginate"));
+        app.allowlistDataTables.column(6).search("Temporary").draw();
         app.showAllowlistLoadingGif = false;
       }, 10);
     })

--- a/web/src/js/index.js
+++ b/web/src/js/index.js
@@ -322,6 +322,9 @@ function getExecutionLogList() {
           ],
           order: [[0, "desc"]],
         });
+        $("#execution-log-list-table-paginate").html(
+          $("#execution-log-list-table_paginate")
+        );
       }, 10);
       app.showExecutionLogListLoadingGif = false;
     })
@@ -431,9 +434,9 @@ function getAllowlist() {
             dataSrc: 6,
           },
         });
+        $("#allowlist-paginate").html($("#allowlist_paginate"));
+        app.showAllowlistLoadingGif = false;
       }, 10);
-
-      app.showAllowlistLoadingGif = false;
     })
     .catch((error) => {
       iziToast.error({

--- a/web/src/js/index.js
+++ b/web/src/js/index.js
@@ -115,8 +115,8 @@ var app = new Vue({
         // $("html").removeClass("remove-overflow");
         this.allowlistExpanded = false;
       } else {
-        $("#allowlist-message-body").css({ "max-height": "calc(88vh)" });
-        $("#allowlist-message-body").css({ "min-height": "calc(88vh)" });
+        $("#allowlist-message-body").css({ "max-height": "calc(90vh)" });
+        $("#allowlist-message-body").css({ "min-height": "calc(90vh)" });
         $("#allowlist-expand-icon").attr(
           "class",
           "fas fa-down-left-and-up-right-to-center"
@@ -140,8 +140,8 @@ var app = new Vue({
         // $("html").removeClass("remove-overflow");
         this.executionLogExpanded = false;
       } else {
-        $("#execution-log-message-body").css({ "max-height": "calc(88vh)" });
-        $("#execution-log-message-body").css({ "min-height": "calc(88vh)" });
+        $("#execution-log-message-body").css({ "max-height": "calc(90vh)" });
+        $("#execution-log-message-body").css({ "min-height": "calc(90vh)" });
         $("#execution-log-expand-icon").attr(
           "class",
           "fas fa-down-left-and-up-right-to-center"
@@ -193,6 +193,16 @@ var app = new Vue({
     },
     searchAllowlist: function () {
       this.allowlistDataTables.search(this.allowlistSearchTerm).draw();
+    },
+    showTemporaryAllowlist: function () {
+      this.allowlistDataTables.column(6).search("Temporary").draw();
+      $("#show-temporary-allowlist-button").addClass("is-link");
+      $("#show-permanent-allowlist-button").removeClass("is-link");
+    },
+    showPermanentAllowlist: function () {
+      this.allowlistDataTables.column(6).search("Permanent").draw();
+      $("#show-permanent-allowlist-button").addClass("is-link");
+      $("#show-temporary-allowlist-button").removeClass("is-link");
     },
     // Execution Log
     closeExecutionLogPopup: function () {
@@ -479,15 +489,11 @@ function getAllowlist() {
             {
               targets: [6],
               visible: false,
-              searchable: false,
             },
             { responsivePriority: 1, targets: 7 },
           ],
           order: [[6, "desc"]],
           pageLength: 500,
-          rowGroup: {
-            dataSrc: 6,
-          },
         });
         $("#allowlist-paginate").html($("#allowlist_paginate"));
         app.showAllowlistLoadingGif = false;

--- a/web/src/js/index.js
+++ b/web/src/js/index.js
@@ -20,6 +20,8 @@ var app = new Vue({
   data: {
     accountId: "",
     apiKey: "",
+    allowlistExpanded: false,
+    executionLogExpanded: false,
     executionLogActionStats: {},
     executionLogDataTables: "",
     executionLogKey: "",
@@ -101,6 +103,49 @@ var app = new Vue({
       };
 
       sendApiRequest(convertJsonToGet(formData), "DELETE");
+    },
+    expandAllowlist: function () {
+      if (this.allowlistExpanded) {
+        $("#allowlist-message-body").css({ "max-height": "calc(36vh)" });
+        $("#allowlist-message-body").css({ "min-height": "" });
+        $("#allowlist-expand-icon").attr(
+          "class",
+          "fas fa-up-right-and-down-left-from-center"
+        );
+        // $("html").removeClass("remove-overflow");
+        this.allowlistExpanded = false;
+      } else {
+        $("#allowlist-message-body").css({ "max-height": "calc(83vh)" });
+        $("#allowlist-message-body").css({ "min-height": "calc(83vh)" });
+        $("#allowlist-expand-icon").attr(
+          "class",
+          "fas fa-down-left-and-up-right-to-center"
+        );
+        // $("html").addClass("remove-overflow");
+        this.allowlistExpanded = true;
+      }
+    },
+    expandExecutionLog: function () {
+      if (this.executionLogExpanded) {
+        $("#execution-log-message-body").css({ "max-height": "calc(36vh)" });
+        $("#execution-log-message-body").css({ "min-height": "" });
+        $("#execution-log-expand-icon").attr(
+          "class",
+          "fas fa-up-right-and-down-left-from-center"
+        );
+        // $("html").removeClass("remove-overflow");
+        this.executionLogExpanded = false;
+      } else {
+        $("#execution-log-message-body").css({ "max-height": "calc(88vh)" });
+        $("#execution-log-message-body").css({ "min-height": "calc(88vh)" });
+        $("#execution-log-expand-icon").attr(
+          "class",
+          "fas fa-down-left-and-up-right-to-center"
+        );
+        $("html, body").animate({ scrollTop: $(document).height() }, 1000);
+        // $("html").addClass("remove-overflow");
+        this.executionLogExpanded = true;
+      }
     },
     extendAllowlistEntry: function (rowId) {
       let row = this.allowlist[rowId - 1];
@@ -320,6 +365,7 @@ function getExecutionLogList() {
             { orderable: false, targets: [0, 1, 2] },
             { className: "dt-center", targets: [2] },
           ],
+          pageLength: 500,
           order: [[0, "desc"]],
         });
         $("#execution-log-list-table-paginate").html(
@@ -429,7 +475,7 @@ function getAllowlist() {
             { responsivePriority: 1, targets: 7 },
           ],
           order: [[6, "desc"]],
-          pageLength: 20,
+          pageLength: 500,
           rowGroup: {
             dataSrc: 6,
           },


### PR DESCRIPTION
## Description

- Updated Allowlist display hiding Owner and Comment columns behind a expand button. This will allow for a more clean display of resources and their ID's.
- Changed the date used to calculate the age of an EC2 Instance. Instead of using the EC2 Instance `LaunchTime` which resets everytime an EC2 Instance is stopped and started, the EC2 Instance's ENI `AttachTime` is used instead. [#129](https://github.com/servian/aws-auto-cleanup/issues/129).
- Updated homescreen design with an encapsulated allowlist and execution log, including a number of QoL changes.

### Related issue(s) (if applicable)

- Fixes #129