### PR TITLE
cleanup role - added cloudformation:ListStacks access as a result of AWS API update

### DIFF
--- a/app/serverless.yml
+++ b/app/serverless.yml
@@ -44,6 +44,7 @@ provider:
             - cloudformation:DescribeStacks
             - cloudformation:DescribeStackResources
             - cloudformation:ListStackResources
+            - cloudformation:ListStacks
             - cloudformation:UpdateTerminationProtection
           Resource: "*"
         - Effect: Allow


### PR DESCRIPTION
## Description

Added cloudformation:ListStacks access to the cleanup role. AWS updated the DescribeStacks API, and as part of this, ListStacks neds to be added when DescribeStacks is used  without specifying a resource.

### Related issue(s) (if applicable)

- N/A

## Checklist

### Generic

- [X] Have you followed the guidelines in our [Contributing](https://github.com/servian/aws-auto-cleanup/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/servian/aws-auto-cleanup/pulls) for the same update/change?

### Development

- [N/A] Have you added comments to all relevant changes within the code?
- [N/A] Have you lint your code locally prior to submission?
- [N/A] Have you formatted (Python Black and Prettier) your code locally prior to submission?

### Testing

- [N/A] Have you created new tests for your submission?
- [N/A] Does your submission pass all tests?
- [X] Does your submission improve or at the very least kept code coverage at the same percentage?

### Documentation

- [N/A] Have you added or changed any and all applicable documentation?
